### PR TITLE
Tasting Type Records named after specs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Spec is implemented using reified protocols. This makes extending current specs 
 (require '[clojure.spec :as s])
 (require '[spec-tools.core :as st])
 
-(def my-integer? (st/type ::st/integer integer?))
+(def my-integer? (st/type ::st/long integer?))
 
 my-integer?
-; #Type{:hint :spec-tools.core/integer
+; #Type{:hint :spec-tools.core/long
 ;       :pred clojure.core/integer?}
 
 (my-integer? 1)
@@ -36,13 +36,12 @@ my-integer?
 ; true
 
 (assoc my-integer? :info {:description "It's a int"})
-; #Type{:hint :spec-tools.core/integer
+; #Type{:hint :spec-tools.core/long
 ;       :pred clojure.core/integer?
 ;       :info {:description "It's a int"}}
 
-
-(eval (s/form (st/type ::st/integer integer? {:description "It's a int"})))
-; #Type{:hint :spec-tools.core/integer
+(eval (s/form (st/type ::st/long integer? {:description "It's a int"})))
+; #Type{:hint :spec-tools.core/long
 ;       :pred clojure.core/integer?
 ;       :info {:description "It's a int"}}
 ```
@@ -53,14 +52,14 @@ Type records also support [dynamic conforming](#dynamic-conforming), making them
 
 | type             | type hint        | predicate       |
 | -----------------|------------------|-----------------|
-| `st/String`      | `::st/string`    | `string?`       |
-| `st/Integer`     | `::st/long`      | `integer?`      |
-| `st/Int`         | `::st/long`      | `int?`          |
-| `st/Double`      | `::st/double`    | `double?`       |
-| `st/Keyword`     | `::st/keyword`   | `keyword?`      |
-| `st/Boolean`     | `::st/boolean`   | `boolean?`      |
-| `st/UUID`        | `::st/uuid`      | `uuid?`         |
-| `st/Inst`        | `::st/date-time` | `inst?`         |
+| `st/string?`     | `::st/string`    | `string?`       |
+| `st/integer?`    | `::st/long`      | `integer?`      |
+| `st/int?`        | `::st/long`      | `int?`          |
+| `st/double?`     | `::st/double`    | `double?`       |
+| `st/keyword?`    | `::st/keyword`   | `keyword?`      |
+| `st/boolean?`    | `::st/boolean`   | `boolean?`      |
+| `st/uuid?`       | `::st/uuid`      | `uuid?`         |
+| `st/inst?`       | `::st/date-time` | `inst?`         |
 
 **TODO**: support all common common types & `clojure.core` predicates.
 
@@ -83,12 +82,12 @@ In `spec-tools.core` there is a modified `conform` supporting setting the confor
 #### Conforming examples
 
 ```clj
-(s/def ::age (s/and st/Integer #(> % 18)))
+(s/def ::age (s/and st/integer? #(> % 18)))
 
 ;; no conforming
 (s/conform ::age "20")
 (st/conform ::age "20")
-(st/conform ::age nil)
+(st/conform ::age "20" nil)
 ; ::s/invalid
 
 ;; json-conforming
@@ -104,11 +103,11 @@ In `spec-tools.core` there is a modified `conform` supporting setting the confor
 
 ```clj
 (s/def ::name string?)
-(s/def ::birthdate st/Inst)
+(s/def ::birthdate st/inst?)
 
 (s/def ::languages
   (s/coll-of
-    (s/and st/Keyword #{:clj :cljs})
+    (s/and st/keyword? #{:clj :cljs})
     :into #{}))
 
 (s/def ::user
@@ -152,13 +151,13 @@ Default conformers are just data, so extending them is easy:
           str/reverse
           str/upper-case))))
 
-(st/conform st/Keyword "kikka")
+(st/conform st/keyword? "kikka")
 ; ::s/invalid
 
-(st/conform st/Keyword "kikka" st/string-conformers)
+(st/conform st/keyword? "kikka" st/string-conformers)
 ; :kikka
 
-(st/conform st/Keyword "kikka" my-conformers)
+(st/conform st/keyword? "kikka" my-conformers)
 ; :AKKIK
 ```
 

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -1,12 +1,13 @@
 (ns spec-tools.core
-  (:refer-clojure :exclude #?(:clj [type]
-                              :cljs [type Inst Keyword UUID]))
+  (:refer-clojure :exclude [type string? integer? int? double? keyword? boolean? uuid? inst?
+                            #?@(:cljs [Inst Keyword UUID])])
   #?(:cljs (:require-macros [spec-tools.core :refer [type]]))
   (:require
     [spec-tools.impl :as impl]
     [spec-tools.convert :as convert]
     [clojure.spec :as s]
-    #?@(:clj  [[clojure.spec.gen :as gen]]
+    #?@(:clj  [
+    [clojure.spec.gen :as gen]]
         :cljs [[goog.date.UtcDateTime]
                [goog.date.Date]
                [clojure.test.check.generators]
@@ -59,11 +60,9 @@
   (conform* [_ x]
     (if (pred x)
       x
-      (if (string? x)
-        (if-let [conformer (get *conformers* hint)]
-          (conformer x)
-          '::s/invalid)
-        ::s/invalid)))
+      (if-let [conformer (get *conformers* hint)]
+        (conformer x)
+        '::s/invalid)))
   (unform* [_ x] x)
   (explain* [_ path via in x]
     (when (= ::s/invalid (if (pred x) x ::s/invalid))
@@ -105,26 +104,11 @@
 ;; Types
 ;;
 
-#?(:clj (ns-unmap *ns* 'String))
-(def spec-tools.core/String (type ::string string?))
-
-#?(:clj (ns-unmap *ns* 'Integer))
-(def spec-tools.core/Integer (type ::long integer?))
-
-#?(:clj (ns-unmap *ns* 'Int))
-(def spec-tools.core/Int (type ::long int?))
-
-#?(:clj (ns-unmap *ns* 'Double))
-(def spec-tools.core/Double (type ::double #?(:clj  double?
-                                               :cljs number?)))
-
-#?(:clj (ns-unmap *ns* 'Keyword))
-(def spec-tools.core/Keyword (type ::keyword keyword?))
-
-#?(:clj (ns-unmap *ns* 'Boolean))
-(def spec-tools.core/Boolean (type ::boolean boolean?))
-
-(def spec-tools.core/UUID (type ::uuid uuid?))
-
-#?(:clj (ns-unmap *ns* 'Inst))
-(def spec-tools.core/Inst (type ::date-time inst?))
+(def spec-tools.core/string? (type ::string clojure.core/string?))
+(def spec-tools.core/integer? (type ::long clojure.core/integer?))
+(def spec-tools.core/int? (type ::long clojure.core/int?))
+(def spec-tools.core/double? (type ::double #?(:clj clojure.core/double?, :cljs clojure.core/number?)))
+(def spec-tools.core/keyword? (type ::keyword clojure.core/keyword?))
+(def spec-tools.core/boolean? (type ::boolean clojure.core/boolean?))
+(def spec-tools.core/uuid? (type ::uuid clojure.core/uuid?))
+(def spec-tools.core/inst? (type ::date-time clojure.core/inst?))

--- a/test/spec_tools/core_test.cljc
+++ b/test/spec_tools/core_test.cljc
@@ -4,16 +4,16 @@
             [spec-tools.core :as st]
             [clojure.string :as str]))
 
-(s/def ::age (s/and st/Integer #(> % 10)))
-(s/def ::over-a-million (s/and st/Int #(> % 1000000)))
-(s/def ::lat st/Double)
-(s/def ::language (s/and st/Keyword #{:clojure :clojurescript}))
-(s/def ::truth st/Boolean)
-(s/def ::uuid st/UUID)
-(s/def ::birthdate st/Inst)
+(s/def ::age (s/and st/integer? #(> % 10)))
+(s/def ::over-a-million (s/and st/int? #(> % 1000000)))
+(s/def ::lat st/double?)
+(s/def ::language (s/and st/keyword? #{:clojure :clojurescript}))
+(s/def ::truth st/boolean?)
+(s/def ::uuid st/uuid?)
+(s/def ::birthdate st/inst?)
 
 (deftest types-test
-  (let [my-integer? (st/type ::st/integer integer?)]
+  (let [my-integer? (st/type ::st/long integer?)]
     (testing "types work as predicates"
       (is (true? (my-integer? 1)))
       (is (false? (my-integer? "1"))))
@@ -29,10 +29,10 @@
 
       (testing "fully qualifed predicate symbol is returned with s/form"
         (is (= ['spec-tools.core/type
-                ::st/integer
+                ::st/long
                 #?(:clj  'clojure.core/integer?
                    :cljs 'cljs.core/integer?)] (s/form my-integer?)))
-        (is (= ['type ::st/integer 'integer?] (s/describe my-integer?))))
+        (is (= ['type ::st/long 'integer?] (s/describe my-integer?))))
 
       (testing "spec serialization"
         (let [spec (st/type ::integer clojure.core/integer? {:description "cool"})]
@@ -103,6 +103,6 @@
                                  str/reverse
                                  str/upper-case)))]
     (testing "string-conformers"
-      (is (= :kikka (st/conform st/Keyword "kikka" st/string-conformers))))
+      (is (= :kikka (st/conform st/keyword? "kikka" st/string-conformers))))
     (testing "my-conformers"
-      (is (= :AKKIK (st/conform st/Keyword "kikka" my-conformations))))))
+      (is (= :AKKIK (st/conform st/keyword? "kikka" my-conformations))))))

--- a/test/spec_tools/perf_test.clj
+++ b/test/spec_tools/perf_test.clj
@@ -22,7 +22,7 @@
 ;;
 
 (spec/def ::age (spec/and integer? #(> % 10)))
-(spec/def ::x-age (spec/and st/Integer #(> % 10)))
+(spec/def ::x-age (spec/and st/integer? #(> % 10)))
 
 (def age (schema/constrained schema/Int #(> % 10)))
 
@@ -110,7 +110,7 @@
 
   (suite "conforming set of keywords")
 
-  (let [sizes-spec (spec/coll-of (spec/and st/Keyword #{:L :M :S}) :into #{})
+  (let [sizes-spec (spec/coll-of (spec/and st/keyword? #{:L :M :S}) :into #{})
         sizes-schema #{(schema/enum :L :M :S)}]
 
     ; 4300ns
@@ -145,15 +145,15 @@
       (cc/quick-bench
         (call)))))
 
-(s/def ::order-id st/Integer)
-(s/def ::product-id st/Integer)
-(s/def ::product-name st/String)
-(s/def ::price st/Double)
-(s/def ::quantity st/Integer)
-(s/def ::name st/String)
-(s/def ::zip st/Integer)
+(s/def ::order-id st/integer?)
+(s/def ::product-id st/integer?)
+(s/def ::product-name st/string?)
+(s/def ::price st/double?)
+(s/def ::quantity st/integer?)
+(s/def ::name st/string?)
+(s/def ::zip st/integer?)
 (s/def ::street string?)
-(s/def ::country (s/and st/Keyword #{:fi :po}))
+(s/def ::country (s/and st/keyword? #{:fi :po}))
 (s/def ::receiver (s/keys :req-un [::name ::street ::zip]
                           :opt-un [::country]))
 (s/def ::orderline (s/keys :req-un [::product-id ::price]


### PR DESCRIPTION
Tested how the type records would look if they would be named like core/spec predicates. Why? Having a type `st/Long` gives actually no guarantees that the type would be `java.lang.Long` after conform => only strings are conformed and thus the type predicate rule actually is:

* validate type against a predicata (plain clojure.spec)
* if type is string, then conform using type-hint based conformer

Hmm.