### PR TITLE
Re-factor the spec walking into its own component

### DIFF
--- a/src/spec_tools/json_schema.clj
+++ b/src/spec_tools/json_schema.clj
@@ -1,6 +1,7 @@
 (ns spec-tools.json-schema
   "Tools for converting specs into JSON Schemata."
-  (:require [clojure.spec :as s]))
+  (:require [clojure.spec :as s]
+            [spec-tools.visitor :as visitor :refer [visit]]))
 
 (defn- strip-fn-if-needed [form]
   (let [head (first form)]
@@ -10,96 +11,89 @@
       (nth form 2)
       form)))
 
-(defn- spec-dispatch
-  [spec]
-  (cond
-    (or (s/spec? spec) (s/regex? spec) (keyword? spec))
-    (let [form (s/form spec)]
-      (if (not= form :clojure.spec/unknown)
-        (if (seq? form)
-          (first form)
-          (spec-dispatch form))
-        spec))
-    (set? spec) ::set
-    (seq? spec) (first (strip-fn-if-needed spec))
-    :else spec))
-
-(defn- formize [spec] (if (seq? spec) spec (s/form spec)))
+(defn- only-entry? [key a-map] (= [key] (keys a-map)))
 
 (defn- simplify-all-of [spec]
   (let [subspecs (->> (:allOf spec) (remove empty?))]
     (cond
       (empty? subspecs) (dissoc spec :allOf)
-      (and (= (count subspecs) 1) (= [:allOf] (keys spec))) (first subspecs)
+      (and (= (count subspecs) 1) (only-entry? :allOf spec)) (first subspecs)
       :else (assoc spec :allOf subspecs))))
 
-(defmulti to-json "Convert a spec into a JSON Schema." spec-dispatch :default ::default)
+(defn- unwrap
+  "Unwrap [x] to x. Asserts that coll has exactly one element."
+  [coll]
+  {:pre [(= 1 (count coll))]}
+  (first coll))
 
-(defmethod to-json 'clojure.core/int? [spec] {:type "integer"})
-(defmethod to-json 'clojure.core/integer? [spec] {:type "integer"})
+(defn- spec-dispatch [dispatch spec children] dispatch)
+(defmulti accept-spec spec-dispatch :default ::default)
 
-(defmethod to-json 'clojure.core/float? [spec] {:type "number"})
-(defmethod to-json 'clojure.core/double? [spec] {:type "number"})
+(defmethod accept-spec 'clojure.core/int? [_ _ _] {:type "integer"})
+(defmethod accept-spec 'clojure.core/integer? [_ _ _] {:type "integer"})
 
-(defmethod to-json 'clojure.core/pos? [spec] {:minimum 0 :exclusiveMinimum true})
-(defmethod to-json 'clojure.core/neg? [spec] {:maximum 0 :exclusiveMaximum true})
+(defmethod accept-spec 'clojure.core/float? [_ _ _] {:type "number"})
+(defmethod accept-spec 'clojure.core/double? [_ _ _] {:type "number"})
 
-(defmethod to-json 'clojure.core/string? [spec] {:type "string"})
-(defmethod to-json 'clojure.core/keyword? [spec] {:type "string"})
+(defmethod accept-spec 'clojure.core/pos? [_ _ _] {:minimum 0 :exclusiveMinimum true})
+(defmethod accept-spec 'clojure.core/neg? [_ _ _] {:maximum 0 :exclusiveMaximum true})
 
-(defmethod to-json 'clojure.core/boolean? [spec] {:type "boolean"})
+(defmethod accept-spec 'clojure.core/string? [_ _ _] {:type "string"})
+(defmethod accept-spec 'clojure.core/keyword? [_ _ _] {:type "string"})
 
-(defmethod to-json 'clojure.core/nil? [spec] {:type "null"})
+(defmethod accept-spec 'clojure.core/boolean? [_ _ _] {:type "boolean"})
 
-(defmethod to-json ::set [spec]
-  {:enum (vec (if (keyword? spec) (s/form spec) spec))})
+(defmethod accept-spec 'clojure.core/nil? [_ _ _] {:type "null"})
 
-(defmethod to-json 'clojure.spec/every [spec]
-  (let [[_ inner-spec & kwargs] (formize spec)
+(defmethod accept-spec ::visitor/set [dispatch spec children]
+  {:enum children})
+
+(defn- is-map-of?
+  "Predicate to check if spec looks like an expansion of clojure.spec/map-of."
+  [spec]
+  (let [[_ inner-spec & {:as kwargs}] (s/form spec)
         pred (when (seq? inner-spec) (first inner-spec))]
-    ;; Special case handling for (s/map-of). If someone actually wants to have a
-    ;; list of tuples in their JSON, this will break.
-    (if (and (= pred 'clojure.spec/tuple)
-             (= (get (into {} (map vec (partition 2 kwargs))) :into)) {})
-      {:type "object" :additionalProperties (get-in (to-json inner-spec) [:items 1])}
-      {:type "array" :items (to-json inner-spec)})))
+    ;; (s/map-of key-spec value-spec) expands to
+    ;; (s/every (s/tuple key-spec value-spec) :into {} ...)
+    (and (= pred 'clojure.spec/tuple) (= (get kwargs :into)) {})))
 
-(defmethod to-json 'clojure.spec/tuple [spec]
-  (let [[_ & inner-specs] (formize spec)]
-    {:type "array" :items (mapv to-json inner-specs) :minItems (count inner-specs)}))
+(defmethod accept-spec 'clojure.spec/every [dispatch spec children]
+  ;; Special case handling of s/map-of, which expands to s/every
+  (if (is-map-of? spec)
+    {:type "object" :additionalProperties (get-in (unwrap children) [:items 1])}
+    {:type "array" :items (unwrap children)}))
 
-(defmethod to-json 'clojure.spec/* [spec]
-  (let [[_ inner-spec] (s/form spec)]
-    {:type "array" :items (to-json inner-spec)}))
+(defmethod accept-spec 'clojure.spec/tuple [dispatch spec children]
+  {:type "array" :items children :minItems (count children)})
 
-(defmethod to-json 'clojure.spec/+ [spec]
-  (let [[_ inner-spec] (s/form spec)]
-    {:type "array" :items (to-json inner-spec) :minItems 1}))
+(defmethod accept-spec 'clojure.spec/* [dispatch spec children]
+  {:type "array" :items (unwrap children)})
 
-(defmethod to-json 'clojure.spec/keys [spec]
+(defmethod accept-spec 'clojure.spec/+ [dispatch spec children]
+  {:type "array" :items (unwrap children) :minItems 1})
+
+(defmethod accept-spec 'clojure.spec/keys [dispatch spec children]
   (let [[_ & {:keys [req req-un opt opt-un]}] (s/form spec)
-        properties (into {} (map (juxt name to-json)
-                                 (concat req req-un opt opt-un)))]
+        names (map name (concat req req-un opt opt-un))
+        required (map name (concat req req-un))]
     {:type "object"
-     :properties properties
-     :required (map name (concat req req-un))}))
+     :properties (zipmap names children)
+     :required required}))
 
-(defmethod to-json 'clojure.spec/or [spec]
-  (let [[_ & {:as inner-spec-map}] (s/form spec)]
-    {:anyOf (mapv to-json (vals inner-spec-map))}))
+(defmethod accept-spec 'clojure.spec/or [dispatch spec children]
+  {:anyOf children})
 
-(defmethod to-json 'clojure.spec/and [spec]
-  (let [[_ & inner-specs] (s/form spec)]
-    (simplify-all-of {:allOf (mapv to-json inner-specs)})))
+(defmethod accept-spec 'clojure.spec/and [dispatch spec children]
+  (simplify-all-of {:allOf children}))
 
-(defmethod to-json 'clojure.spec/nilable [spec]
-  (let [[_ inner-spec] (s/form spec)]
-    {:oneOf [(to-json inner-spec) {:type "null"}]}))
+(defmethod accept-spec 'clojure.spec/nilable [dispatch spec children]
+  {:oneOf [(unwrap children) {:type "null"}]})
 
-(defmethod to-json 'clojure.spec/int-in-range? [spec]
-  (let [[_ minimum maximum _] (strip-fn-if-needed spec)]
+(defmethod accept-spec 'clojure.spec/int-in-range? [dispatch spec children]
+  (let [[_ minimum maximum _] (visitor/strip-fn-if-needed spec)]
     {:minimum minimum :maximum maximum}))
 
-(defmethod to-json ::default [spec]
-  (prn :UNKNOWN (spec-dispatch spec) spec)
+(defmethod accept-spec ::default [dispatch spec children]
   {})
+
+(defn to-json [spec] (visit spec accept-spec))

--- a/src/spec_tools/visitor.clj
+++ b/src/spec_tools/visitor.clj
@@ -1,0 +1,96 @@
+(ns spec-tools.visitor
+  (:require [clojure.spec :as s]
+            [clojure.set :as set]))
+
+(defn- strip-fn-if-needed [form]
+  (let [head (first form)]
+    ;; Deal with the form (clojure.core/fn [%] (foo ... %))
+    ;; We should just use core.match...
+    (if (and (= (count form) 3) (= head 'clojure.core/fn))
+      (nth form 2)
+      form)))
+
+(defn- formize [spec] (if (seq? spec) spec (s/form spec)))
+
+(defn- spec-dispatch
+  [spec accept]
+  (cond
+    (or (s/spec? spec) (s/regex? spec) (keyword? spec))
+    (let [form (s/form spec)]
+      (if (not= form :clojure.spec/unknown)
+        (if (seq? form)
+          (first form)
+          (spec-dispatch form accept))
+        spec))
+    (set? spec) ::set
+    (seq? spec) (first (strip-fn-if-needed spec))
+    :else spec))
+
+(defmulti visit spec-dispatch :default ::default)
+
+(defmethod visit ::set [spec accept]
+  (accept ::set (vec spec)))
+
+(defmethod visit 'clojure.spec/every [spec accept]
+  (let [[_ inner-spec & kwargs] (formize spec)]
+    (accept 'clojure.spec/every spec [(visit inner-spec accept)])))
+
+(defmethod visit 'clojure.spec/tuple [spec accept]
+  (let [[_ & inner-specs] (formize spec)]
+    (accept 'clojure.spec/tuple spec (mapv #(visit % accept) inner-specs))))
+
+(defmethod visit 'clojure.spec/* [spec accept]
+  (let [[_ inner-spec] (s/form spec)]
+    (accept 'clojure.spec/* spec [(visit inner-spec accept)])))
+
+(defmethod visit 'clojure.spec/+ [spec accept]
+  (let [[_ inner-spec] (s/form spec)]
+    (accept 'clojure.spec/+ spec [(visit inner-spec accept)])))
+
+(defmethod visit 'clojure.spec/keys [spec accept]
+  (let [[_ & {:keys [req req-un opt opt-un]}] (s/form spec)]
+    (accept 'clojure.spec/keys spec (mapv #(visit % accept) (concat req req-un opt opt-un)))))
+
+(defmethod visit 'clojure.spec/or [spec accept]
+  (let [[_ & {:as inner-spec-map}] (s/form spec)]
+    (accept 'clojure.spec/or spec (mapv #(visit % accept) (vals inner-spec-map)))))
+
+(defmethod visit 'clojure.spec/and [spec accept]
+  (let [[_ & inner-specs] (s/form spec)]
+    (accept 'clojure.spec/and spec (mapv #(visit % accept) inner-specs))))
+
+(defmethod visit 'clojure.spec/nilable [spec accept]
+  (let [[_ inner-spec] (s/form spec)]
+    (accept 'clojure.spec/nilable spec [(visit inner-spec accept)])))
+
+(defmethod visit ::default [spec accept]
+  (accept (spec-dispatch spec accept) spec nil))
+
+(s/def ::a string?)
+(s/def ::b integer?)
+(s/def ::f integer?)
+(s/def ::e ::f)
+(s/def ::c (s/keys :req [::a]))
+(s/def ::d (s/tuple ::e integer?))
+(s/def ::foo (s/keys :req [::b ::c ::d]))
+
+(prn (visit ::foo (fn [x y z]
+                    (case x
+                      clojure.spec/keys
+                      (let [[_ & {:keys [req req-un opt opt-un]}] (s/form y)]
+                        {:type "object"
+                         :properties (zipmap (map name (concat req req-un opt opt-un)) z)
+                         :required (mapv name (concat req req-un))})
+                      clojure.core/string?
+                      {:type "string"}
+                      clojure.core/integer?
+                      {:type "number"}
+                      {}
+                      ))))
+
+(prn (visit ::foo (fn [dispatch spec children]
+                    (case dispatch
+                      clojure.spec/keys
+                      (let [[_ & {:keys [req req-un opt opt-un]}] (s/form spec)]
+                        (apply set/union (set (concat req req-un opt opt-un)) children))
+                      (apply set/union (when (keyword? spec) #{spec}) children)))))

--- a/test/spec_tools/core_test.cljc
+++ b/test/spec_tools/core_test.cljc
@@ -53,9 +53,9 @@
              (st/deserialize (st/serialize spec))
              (s/form spec))))))
 
-#_(deftest spec-tools-conform-test
+(deftest spec-tools-conform-test
   (testing "in default mode"
-    #_(testing "nothing is conformed"
+    (testing "nothing is conformed"
       (is (= ::s/invalid (st/conform ::age "12")))
       (is (= ::s/invalid (st/conform ::over-a-million "1234567")))
       (is (= ::s/invalid (st/conform ::lat "23.1234")))

--- a/test/spec_tools/core_test.cljc
+++ b/test/spec_tools/core_test.cljc
@@ -53,9 +53,9 @@
              (st/deserialize (st/serialize spec))
              (s/form spec))))))
 
-(deftest spec-tools-conform-test
+#_(deftest spec-tools-conform-test
   (testing "in default mode"
-    (testing "nothing is conformed"
+    #_(testing "nothing is conformed"
       (is (= ::s/invalid (st/conform ::age "12")))
       (is (= ::s/invalid (st/conform ::over-a-million "1234567")))
       (is (= ::s/invalid (st/conform ::lat "23.1234")))

--- a/test/spec_tools/visitor_test.clj
+++ b/test/spec_tools/visitor_test.clj
@@ -1,0 +1,16 @@
+(ns spec-tools.visitor-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.spec :as s]
+            [spec-tools.visitor :refer [visit]]
+            [clojure.set :as set]))
+
+(s/def ::str string?)
+(s/def ::int integer?)
+(s/def ::map (s/keys :req [::str] :opt [::int]))
+
+(defn collect [dispatch spec children] `[~dispatch ~@children])
+
+(deftest test-visit
+  (is (= (visit #{1 2 3} collect) [:spec-tools.visitor/set 1 3 2]))
+  (is (= (visit ::map collect)
+         '[clojure.spec/keys [clojure.core/string?] [clojure.core/integer?]])))


### PR DESCRIPTION
This way it can be re-used for implementing other things than JSON Schema generation.

This branch is what me and Tommi hacked up in December. It needs some clean-up, but I'll create a PR for it already so that I won't lose track of it. 