### PR TITLE
Resolve type hints automatically and stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Clojure Spec is implemented using reified protocols. This makes extending curren
 (require '[clojure.spec :as s])
 (require '[spec-tools.core :as st])
 
-(def my-integer? (st/spec integer? {:hint :long}))
+(def my-integer? (st/spec integer? {:type :long}))
 
 my-integer?
-; #Spec{:hint :long
+; #Spec{:type :long
 ;       :pred clojure.core/integer?}
 
 (my-integer? 1)
@@ -36,12 +36,12 @@ my-integer?
 ; true
 
 (assoc my-integer? :info {:description "It's a int"})
-; #Spec{:hint :long
+; #Spec{:type :long
 ;       :pred clojure.core/integer?
 ;       :info {:description "It's a int"}}
 
 (eval (s/form (st/spec ::st/long integer? {:description "It's a int"})))
-; #Spec{:hint :long
+; #Spec{:type :long
 ;       :pred clojure.core/integer?
 ;       :info {:description "It's a int"}}
 ```

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Clojure Spec is implemented using reified protocols. This makes extending curren
 (require '[clojure.spec :as s])
 (require '[spec-tools.core :as st])
 
-(def my-integer? (st/spec ::st/long integer?))
+(def my-integer? (st/spec integer? {:hint :long}))
 
 my-integer?
-; #Spec{:hint :spec-tools.core/long
+; #Spec{:hint :long
 ;       :pred clojure.core/integer?}
 
 (my-integer? 1)
@@ -36,12 +36,12 @@ my-integer?
 ; true
 
 (assoc my-integer? :info {:description "It's a int"})
-; #Spec{:hint :spec-tools.core/long
+; #Spec{:hint :long
 ;       :pred clojure.core/integer?
 ;       :info {:description "It's a int"}}
 
 (eval (s/form (st/spec ::st/long integer? {:description "It's a int"})))
-; #Spec{:hint :spec-tools.core/long
+; #Spec{:hint :long
 ;       :pred clojure.core/integer?
 ;       :info {:description "It's a int"}}
 ```
@@ -52,14 +52,14 @@ Spec records also support [dynamic conforming](#dynamic-conforming), making them
 
 | spec             | type hint        | predicate       |
 | -----------------|------------------|-----------------|
-| `st/string?`     | `::st/string`    | `string?`       |
-| `st/integer?`    | `::st/long`      | `integer?`      |
-| `st/int?`        | `::st/long`      | `int?`          |
-| `st/double?`     | `::st/double`    | `double?`       |
-| `st/keyword?`    | `::st/keyword`   | `keyword?`      |
-| `st/boolean?`    | `::st/boolean`   | `boolean?`      |
-| `st/uuid?`       | `::st/uuid`      | `uuid?`         |
-| `st/inst?`       | `::st/date`      | `inst?`         |
+| `st/string?`     | `:string`    | `string?`       |
+| `st/integer?`    | `:long`      | `integer?`      |
+| `st/int?`        | `:long`      | `int?`          |
+| `st/double?`     | `:double`    | `double?`       |
+| `st/keyword?`    | `:keyword`   | `keyword?`      |
+| `st/boolean?`    | `:boolean`   | `boolean?`      |
+| `st/uuid?`       | `:uuid`      | `uuid?`         |
+| `st/inst?`       | `:date`      | `inst?`         |
 
 **TODO**: support all common common specs & `clojure.core` predicates.
 
@@ -243,6 +243,6 @@ WIP: https://github.com/metosin/spec-tools/blob/master/test/spec_tools/json_sche
 
 ## License
 
-Copyright © 2016 [Metosin Oy](http://www.metosin.fi)
+Copyright © 2016-2017 [Metosin Oy](http://www.metosin.fi)
 
 Distributed under the Eclipse Public License, the same as Clojure.

--- a/src/spec_tools/conform.cljc
+++ b/src/spec_tools/conform.cljc
@@ -2,7 +2,8 @@
   #?(:cljs (:refer-clojure :exclude [Inst Keyword UUID]))
   (:require [clojure.spec :as s]
     #?@(:cljs [[goog.date.UtcDateTime]
-               [goog.date.Date]]))
+               [goog.date.Date]])
+            [clojure.string :as str])
   #?(:clj
      (:import (java.util Date UUID)
               (java.time Instant))))
@@ -58,6 +59,14 @@
       (catch #?(:clj  Exception
                 :cljs js/Error) _
         ::s/invalid))))
+
+(defn string->symbol [_ x]
+  (if (string? x)
+    (symbol x)))
+
+(defn string->nil [_ x]
+  (if-not (str/blank? x)
+    ::s/invalid))
 
 ;;
 ;; Maps

--- a/src/spec_tools/conform.cljc
+++ b/src/spec_tools/conform.cljc
@@ -63,7 +63,7 @@
 ;; Maps
 ;;
 
-(defn map->strip-extra-keys [{:keys [keys pred]} x]
+(defn strip-extra-keys [{:keys [keys pred]} x]
   (if (map? x)
     (s/conform pred (select-keys x keys))
     x))

--- a/src/spec_tools/conform.cljc
+++ b/src/spec_tools/conform.cljc
@@ -1,4 +1,4 @@
-(ns spec-tools.convert
+(ns spec-tools.conform
   #?(:cljs (:refer-clojure :exclude [Inst Keyword UUID]))
   (:require [clojure.spec :as s]
     #?@(:cljs [[goog.date.UtcDateTime]
@@ -6,6 +6,10 @@
   #?(:clj
      (:import (java.util Date UUID)
               (java.time Instant))))
+
+;;
+;; Strings
+;;
 
 (defn string->long [_ x]
   (if (string? x)
@@ -54,3 +58,12 @@
       (catch #?(:clj  Exception
                 :cljs js/Error) _
         ::s/invalid))))
+
+;;
+;; Maps
+;;
+
+(defn map->strip-extra-keys [{:keys [keys pred]} x]
+  (if (map? x)
+    (s/conform pred (select-keys x keys))
+    x))

--- a/src/spec_tools/convert.cljc
+++ b/src/spec_tools/convert.cljc
@@ -4,7 +4,7 @@
     #?@(:cljs [[goog.date.UtcDateTime]
                [goog.date.Date]]))
   #?(:clj
-     (:import (java.util Date)
+     (:import (java.util Date UUID)
               (java.time Instant))))
 
 (defn string->long [_ x]
@@ -19,7 +19,7 @@
 (defn string->double [_ x]
   (if (string? x)
     (try
-      #?(:clj  (java.lang.Double/parseDouble x)
+      #?(:clj  (Double/parseDouble x)
          :cljs (js/parseFloat x))
       (catch #?(:clj  Exception
                 :cljs js/Error) _
@@ -39,7 +39,7 @@
 (defn string->uuid [_ x]
   (if (string? x)
     (try
-      #?(:clj  (java.util.UUID/fromString x)
+      #?(:clj  (UUID/fromString x)
          :cljs (uuid x))
       (catch #?(:clj  Exception
                 :cljs js/Error) _

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -95,7 +95,7 @@
 (defn- extra-spec-map [t]
   (dissoc t :form :pred :gfn))
 
-(defrecord Spec [hint form pred gfn]
+(defrecord Spec [type form pred gfn]
   #?@(:clj
       [s/Specize
        (specize* [s] s)
@@ -107,7 +107,7 @@
     (if (and (fn? pred) (pred x))
       x
       ;; there is a dynamic conformer
-      (if-let [conformer (get *conformers* hint)]
+      (if-let [conformer (get *conformers* type)]
         (conformer this x)
         ;; spec predicate
         (if (s/spec? pred)
@@ -138,7 +138,7 @@
      (.write w (str "#Spec"
                     (merge
                       {:pred (:form t)}
-                      (if (:hint t) (select-keys t [:hint]))
+                      (if (:type t) (select-keys t [:type]))
                       (extra-spec-map t))))))
 
 
@@ -169,14 +169,14 @@
                        '~(or (and (clojure.core/symbol? pred) (some->> pred (impl/cljs-resolve &env) impl/->sym)) pred)
                        (s/form ~pred))]
            (create-spec
-             {:hint (types/resolve-type form#)
+             {:type (types/resolve-type form#)
               :pred ~pred
               :form form#}))
         `(let [form# (if (clojure.core/symbol? '~pred)
                        '~(or (and (clojure.core/symbol? pred) (some->> pred resolve impl/->sym)) pred)
                        (s/form ~pred))]
            (create-spec
-             {:hint (types/resolve-type form#)
+             {:type (types/resolve-type form#)
               :pred ~pred
               :form form#}))))
      ([pred info]
@@ -189,8 +189,8 @@
            (create-spec
              (merge
                ~info
-               (if-not (contains? info# :hint)
-                 {:hint (types/resolve-type form#)})
+               (if-not (contains? info# :type)
+                 {:type (types/resolve-type form#)})
                {:form form#
                 :pred ~pred})))
         `(let [info# ~info
@@ -201,21 +201,21 @@
            (create-spec
              (merge
                ~info
-               (if-not (contains? info# :hint)
-                 {:hint (types/resolve-type form#)})
+               (if-not (contains? info# :type)
+                 {:type (types/resolve-type form#)})
                {:form form#
                 :pred ~pred})))))))
 
 #?(:clj
    (defmacro doc [pred info]
-     `(spec ~pred (merge ~info {:hint nil}))))
+     `(spec ~pred (merge ~info {:type nil}))))
 
 #?(:clj
    (defmacro typed-spec
-     ([hint pred]
-      `(spec ~pred {:hint ~hint}))
-     ([hint pred info]
-      `(spec ~pred (merge ~info {:hint ~hint})))))
+     ([type pred]
+      `(spec ~pred {:type ~type}))
+     ([type pred info]
+      `(spec ~pred (merge ~info {:type ~type})))))
 
 ;;
 ;; Map Spec

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -304,8 +304,8 @@
 (def simple-symbol? (spec clojure.core/simple-symbol?))
 (def qualified-symbol? (spec clojure.core/qualified-symbol?))
 (def uuid? (spec clojure.core/uuid?))
-(def uri? (spec clojure.core/uri?))                         ;; not in cljs
-(def bigdec? (spec clojure.core/bigdec?))                   ;; not in cljs
+#?(:clj (def uri? (spec clojure.core/uri?)))
+#?(:clj (def bigdec? (spec clojure.core/bigdec?)))
 (def inst? (spec clojure.core/inst?))
 (def seqable? (spec clojure.core/seqable?))
 (def indexed? (spec clojure.core/indexed?))
@@ -319,10 +319,10 @@
 (def false? (spec clojure.core/false?))
 (def true? (spec clojure.core/true?))
 (def zero? (spec clojure.core/zero?))
-(def rational? (spec clojure.core/rational?))               ;; not in cljs
+#?(:clj (def rational? (spec clojure.core/rational?)))
 (def coll? (spec clojure.core/coll?))
 (def empty? (spec clojure.core/empty?))
 (def associative? (spec clojure.core/associative?))
 (def sequential? (spec clojure.core/sequential?))
-(def ratio? (spec clojure.core/ratio?))                     ;; not in cljs
-(def bytes? (spec clojure.core/bytes?))                     ;; not in cljs
+#?(:clj (def ratio? (spec clojure.core/ratio?)))
+#?(:clj (def bytes? (spec clojure.core/bytes?)))

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -63,17 +63,17 @@
 (def ^:dynamic ^:private *conformers* nil)
 
 (def string-conformers
-  {::long convert/string->long
-   ::double convert/string->double
-   ::keyword convert/string->keyword
-   ::boolean convert/string->boolean
-   ::uuid convert/string->uuid
-   ::date convert/string->date})
+  {:long convert/string->long
+   :double convert/string->double
+   :keyword convert/string->keyword
+   :boolean convert/string->boolean
+   :uuid convert/string->uuid
+   :date convert/string->date})
 
 (def json-conformers
-  {::keyword convert/string->keyword
-   ::uuid convert/string->uuid
-   ::date convert/string->date})
+  {:keyword convert/string->keyword
+   :uuid convert/string->uuid
+   :date convert/string->date})
 
 (defn conform
   ([spec value]
@@ -261,11 +261,11 @@
 ;; Specs
 ;;
 
-(def spec-tools.core/string? (spec ::string clojure.core/string?))
-(def spec-tools.core/integer? (spec ::long clojure.core/integer?))
-(def spec-tools.core/int? (spec ::long clojure.core/int?))
-(def spec-tools.core/double? (spec ::double #?(:clj clojure.core/double?, :cljs clojure.core/number?)))
-(def spec-tools.core/keyword? (spec ::keyword clojure.core/keyword?))
-(def spec-tools.core/boolean? (spec ::boolean clojure.core/boolean?))
-(def spec-tools.core/uuid? (spec ::uuid clojure.core/uuid?))
-(def spec-tools.core/inst? (spec ::date clojure.core/inst?))
+(def spec-tools.core/string? (spec :string clojure.core/string?))
+(def spec-tools.core/integer? (spec :long clojure.core/integer?))
+(def spec-tools.core/int? (spec :long clojure.core/int?))
+(def spec-tools.core/double? (spec :double #?(:clj clojure.core/double?, :cljs clojure.core/number?)))
+(def spec-tools.core/keyword? (spec :keyword clojure.core/keyword?))
+(def spec-tools.core/boolean? (spec :boolean clojure.core/boolean?))
+(def spec-tools.core/uuid? (spec :uuid clojure.core/uuid?))
+(def spec-tools.core/inst? (spec :date clojure.core/inst?))

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -68,22 +68,29 @@
 
 (def ^:dynamic ^:private *conformers* nil)
 
-(def string-conformers
-  {:long conform/string->long
-   :double conform/string->double
-   :keyword conform/string->keyword
-   :boolean conform/string->boolean
-   :uuid conform/string->uuid
-   :date conform/string->date})
-
 (def json-conformers
   {:keyword conform/string->keyword
    :uuid conform/string->uuid
-   :date conform/string->date})
+   :date conform/string->date
+   :symbol conform/string->symbol
+   ;; TODO: implement
+   :uri nil
+   :bigdec nil
+   :ratio nil})
+
+(def string-conformers
+  (merge
+    json-conformers
+    {:long conform/string->long
+     :double conform/string->double
+     :boolean conform/string->boolean
+     :nil conform/string->nil
+     :string nil}))
 
 (defn conform
   ([spec value]
-   (s/conform spec value))
+   (binding [*conformers* nil]
+     (s/conform spec value)))
   ([spec value conformers]
    (binding [*conformers* conformers]
      (s/conform spec value))))

--- a/src/spec_tools/impl.cljc
+++ b/src/spec_tools/impl.cljc
@@ -15,9 +15,11 @@
     x))
 
 (defn clojure-core-symbol-or-any [x]
-  (if (and (clojure.core/symbol? x)
-           (= "cljs.core" (namespace x)))
-    (symbol "clojure.core" (name x))
+  (or
+    (if (symbol? x)
+      (if-let [ns (get {"cljs.core" "clojure.core"
+                        "cljs.spec" "clojure.spec"} (namespace x))]
+        (symbol ns (name x))))
     x))
 
 (defn- clj-sym [x]

--- a/src/spec_tools/impl.cljc
+++ b/src/spec_tools/impl.cljc
@@ -14,6 +14,12 @@
     (:name x)
     x))
 
+(defn clojure-core-symbol-or-any [x]
+  (if (and (clojure.core/symbol? x)
+           (= "cljs.core" (namespace x)))
+    (symbol "clojure.core" (name x))
+    x))
+
 (defn- clj-sym [x]
   (if (var? x)
     (let [^Var v x]

--- a/src/spec_tools/types.cljc
+++ b/src/spec_tools/types.cljc
@@ -1,0 +1,129 @@
+(ns spec-tools.types)
+
+(defmulti resolve-type identity :default ::default)
+
+(defmethod resolve-type ::default [x]
+  (println "DEFAULT: " x) nil)
+
+(defn resolve-type-or-fail [x]
+  (or (resolve-type x)
+      (throw
+        (ex-info
+          (str
+            "Can't resolve type of a spec: '" x "'. "
+            "You need to provide a `:spec/type` for the spec or "
+            "add a dispatch function for `spec-tools.types/resolve-type`.")
+          {:spec x}))))
+
+; any? (one-of [(return nil) (any-printable)])
+; some? (such-that some? (any-printable))
+; number? (one-of [(large-integer) (double)])
+
+; integer? (large-integer)
+(defmethod resolve-type 'clojure.core/integer? [_] :long)
+
+; int? (large-integer)
+(defmethod resolve-type 'clojure.core/int? [_] :long)
+
+; pos-int? (large-integer* {:min 1})
+(defmethod resolve-type 'clojure.core/pos-int? [_] :long)
+
+; neg-int? (large-integer* {:max -1})
+(defmethod resolve-type 'clojure.core/neg-int? [_] :long)
+
+; nat-int? (large-integer* {:min 0})
+(defmethod resolve-type 'clojure.core/nat-int? [_] :long)
+
+; float? (double)
+(defmethod resolve-type 'clojure.core/float? [_] :double)
+
+; double? (double)
+(defmethod resolve-type 'clojure.core/double? [_] :double)
+
+; boolean? (boolean)
+(defmethod resolve-type 'clojure.core/boolean? [_] :boolean)
+
+; string? (string-alphanumeric)
+(defmethod resolve-type 'clojure.core/string? [_] :string)
+
+; ident? (one-of [(keyword-ns) (symbol-ns)])
+(defmethod resolve-type 'clojure.core/ident? [_] :keyword)
+
+; simple-ident? (one-of [(keyword) (symbol)])
+(defmethod resolve-type 'clojure.core/simple-ident? [_] :keyword)
+
+; qualified-ident? (such-that qualified? (one-of [(keyword-ns) (symbol-ns)]))
+(defmethod resolve-type 'clojure.core/qualified-ident? [_] :keyword)
+
+; keyword? (keyword-ns)
+(defmethod resolve-type 'clojure.core/keyword? [_] :keyword)
+
+; simple-keyword? (keyword)
+(defmethod resolve-type 'clojure.core/simple-keyword? [_] :keyword)
+
+; qualified-keyword? (such-that qualified? (keyword-ns))
+(defmethod resolve-type 'clojure.core/qualified-keyword? [_] :keyword)
+
+; symbol? (symbol-ns)
+(defmethod resolve-type 'clojure.core/symbol? [_] :symbol)
+
+; simple-symbol? (symbol)
+(defmethod resolve-type 'clojure.core/simple-symbol? [_] :symbol)
+
+; qualified-symbol? (such-that qualified? (symbol-ns))
+(defmethod resolve-type 'clojure.core/qualified-symbol? [_] :symbol)
+
+; uuid? (uuid)
+(defmethod resolve-type 'clojure.core/uuid? [_] :uuid)
+
+; uri? (fmap #(java.net.URI/create (str "http://" % ".com")) (uuid))
+(defmethod resolve-type 'clojure.core/uri? [_] :uri)
+
+; bigdec? (fmap #(BigDecimal/valueOf %)
+;               (double* {:infinite? false :NaN? false}))
+(defmethod resolve-type 'clojure.core/bigdec? [_] :bigdec)
+
+; inst? (fmap #(java.util.Date. %)
+;             (large-integer))
+(defmethod resolve-type 'clojure.core/inst? [_] :date)
+
+; seqable? (one-of [(return nil)
+;                   (list simple)
+;                   (vector simple)
+;                   (map simple simple)
+;                   (set simple)
+;                   (string-alphanumeric)])
+; indexed? (vector simple)
+; map? (map simple simple)
+; vector? (vector simple)
+; list? (list simple)
+; seq? (list simple)
+; char? (char)
+; set? (set simple)
+
+; nil? (return nil)
+(defmethod resolve-type 'clojure.core/nil? [_] :nil)
+
+; false? (return false)
+(defmethod resolve-type 'clojure.core/false? [_] :boolean)
+
+; true? (return true)
+(defmethod resolve-type 'clojure.core/true? [_] :boolean)
+
+; zero? (return 0)
+(defmethod resolve-type 'clojure.core/zero? [_] :long)
+
+; rational? (one-of [(large-integer) (ratio)])
+(defmethod resolve-type 'clojure.core/rational? [_] :long)
+
+; coll? (one-of [(map simple simple)
+;                (list simple)
+;                (vector simple)
+;                (set simple)])
+; empty? (elements [nil '() [] {} #{}])
+; associative? (one-of [(map simple simple) (vector simple)])
+; sequential? (one-of [(list simple) (vector simple)])
+; ratio? (such-that ratio? (ratio))
+(defmethod resolve-type 'clojure.core/ratio? [_] :ratio)
+
+; bytes? (bytes)

--- a/src/spec_tools/types.cljc
+++ b/src/spec_tools/types.cljc
@@ -1,129 +1,65 @@
-(ns spec-tools.types)
+(ns spec-tools.types
+  (:require [spec-tools.impl :as impl]))
 
-(defmulti resolve-type identity :default ::default)
+(defn- error-message [x]
+  (str
+    "Can't resolve type of a spec: '" x "'. "
+    "You need to provide a `:hint` for the spec or "
+    "add a dispatch function for `spec-tools.types/resolve-type`."))
+
+(defmulti resolve-type
+  impl/clojure-core-symbol-or-any
+  :default ::default)
 
 (defmethod resolve-type ::default [x]
-  (println "DEFAULT: " x) nil)
+  (println (error-message x)))
 
 (defn resolve-type-or-fail [x]
-  (or (resolve-type x)
-      (throw
-        (ex-info
-          (str
-            "Can't resolve type of a spec: '" x "'. "
-            "You need to provide a `:spec/type` for the spec or "
-            "add a dispatch function for `spec-tools.types/resolve-type`.")
-          {:spec x}))))
+  (if (contains? (methods resolve-type) x)
+    (resolve-type x)
+    (throw (ex-info (error-message x) {:spec x}))))
 
-; any? (one-of [(return nil) (any-printable)])
-; some? (such-that some? (any-printable))
-; number? (one-of [(large-integer) (double)])
-
-; integer? (large-integer)
+(defmethod resolve-type 'clojure.core/any? [_] nil)
+(defmethod resolve-type 'clojure.core/some? [_] nil)
+(defmethod resolve-type 'clojure.core/number? [_] nil)
 (defmethod resolve-type 'clojure.core/integer? [_] :long)
-
-; int? (large-integer)
 (defmethod resolve-type 'clojure.core/int? [_] :long)
-
-; pos-int? (large-integer* {:min 1})
 (defmethod resolve-type 'clojure.core/pos-int? [_] :long)
-
-; neg-int? (large-integer* {:max -1})
 (defmethod resolve-type 'clojure.core/neg-int? [_] :long)
-
-; nat-int? (large-integer* {:min 0})
 (defmethod resolve-type 'clojure.core/nat-int? [_] :long)
-
-; float? (double)
 (defmethod resolve-type 'clojure.core/float? [_] :double)
-
-; double? (double)
 (defmethod resolve-type 'clojure.core/double? [_] :double)
-
-; boolean? (boolean)
 (defmethod resolve-type 'clojure.core/boolean? [_] :boolean)
-
-; string? (string-alphanumeric)
 (defmethod resolve-type 'clojure.core/string? [_] :string)
-
-; ident? (one-of [(keyword-ns) (symbol-ns)])
 (defmethod resolve-type 'clojure.core/ident? [_] :keyword)
-
-; simple-ident? (one-of [(keyword) (symbol)])
 (defmethod resolve-type 'clojure.core/simple-ident? [_] :keyword)
-
-; qualified-ident? (such-that qualified? (one-of [(keyword-ns) (symbol-ns)]))
 (defmethod resolve-type 'clojure.core/qualified-ident? [_] :keyword)
-
-; keyword? (keyword-ns)
 (defmethod resolve-type 'clojure.core/keyword? [_] :keyword)
-
-; simple-keyword? (keyword)
 (defmethod resolve-type 'clojure.core/simple-keyword? [_] :keyword)
-
-; qualified-keyword? (such-that qualified? (keyword-ns))
 (defmethod resolve-type 'clojure.core/qualified-keyword? [_] :keyword)
-
-; symbol? (symbol-ns)
 (defmethod resolve-type 'clojure.core/symbol? [_] :symbol)
-
-; simple-symbol? (symbol)
 (defmethod resolve-type 'clojure.core/simple-symbol? [_] :symbol)
-
-; qualified-symbol? (such-that qualified? (symbol-ns))
 (defmethod resolve-type 'clojure.core/qualified-symbol? [_] :symbol)
-
-; uuid? (uuid)
 (defmethod resolve-type 'clojure.core/uuid? [_] :uuid)
-
-; uri? (fmap #(java.net.URI/create (str "http://" % ".com")) (uuid))
 (defmethod resolve-type 'clojure.core/uri? [_] :uri)
-
-; bigdec? (fmap #(BigDecimal/valueOf %)
-;               (double* {:infinite? false :NaN? false}))
 (defmethod resolve-type 'clojure.core/bigdec? [_] :bigdec)
-
-; inst? (fmap #(java.util.Date. %)
-;             (large-integer))
 (defmethod resolve-type 'clojure.core/inst? [_] :date)
-
-; seqable? (one-of [(return nil)
-;                   (list simple)
-;                   (vector simple)
-;                   (map simple simple)
-;                   (set simple)
-;                   (string-alphanumeric)])
-; indexed? (vector simple)
-; map? (map simple simple)
-; vector? (vector simple)
-; list? (list simple)
-; seq? (list simple)
-; char? (char)
-; set? (set simple)
-
-; nil? (return nil)
+(defmethod resolve-type 'clojure.core/seqable? [_] nil)
+(defmethod resolve-type 'clojure.core/indexed? [_] nil)
+(defmethod resolve-type 'clojure.core/map? [_] nil)
+(defmethod resolve-type 'clojure.core/vector? [_] nil)
+(defmethod resolve-type 'clojure.core/list? [_] nil)
+(defmethod resolve-type 'clojure.core/seq? [_] nil)
+(defmethod resolve-type 'clojure.core/char? [_] nil)
+(defmethod resolve-type 'clojure.core/set? [_] nil)
 (defmethod resolve-type 'clojure.core/nil? [_] :nil)
-
-; false? (return false)
 (defmethod resolve-type 'clojure.core/false? [_] :boolean)
-
-; true? (return true)
 (defmethod resolve-type 'clojure.core/true? [_] :boolean)
-
-; zero? (return 0)
 (defmethod resolve-type 'clojure.core/zero? [_] :long)
-
-; rational? (one-of [(large-integer) (ratio)])
 (defmethod resolve-type 'clojure.core/rational? [_] :long)
-
-; coll? (one-of [(map simple simple)
-;                (list simple)
-;                (vector simple)
-;                (set simple)])
-; empty? (elements [nil '() [] {} #{}])
-; associative? (one-of [(map simple simple) (vector simple)])
-; sequential? (one-of [(list simple) (vector simple)])
-; ratio? (such-that ratio? (ratio))
+(defmethod resolve-type 'clojure.core/coll? [_] nil)
+(defmethod resolve-type 'clojure.core/empty? [_] nil)
+(defmethod resolve-type 'clojure.core/associative? [_] nil)
+(defmethod resolve-type 'clojure.core/sequential? [_] nil)
 (defmethod resolve-type 'clojure.core/ratio? [_] :ratio)
-
-; bytes? (bytes)
+(defmethod resolve-type 'clojure.core/bytes? [_] nil)

--- a/src/spec_tools/types.cljc
+++ b/src/spec_tools/types.cljc
@@ -7,9 +7,21 @@
     "You need to provide a `:hint` for the spec or "
     "add a dispatch function for `spec-tools.types/resolve-type`."))
 
-(defmulti resolve-type
-  impl/clojure-core-symbol-or-any
-  :default ::default)
+(defn- dispatch [x]
+  (cond
+
+    ;; symbol
+    (symbol? x)
+    (impl/clojure-core-symbol-or-any x)
+
+    ;; a from
+    (seq? x)
+    (impl/clojure-core-symbol-or-any (first x))
+
+    ;; default
+    :else x))
+
+(defmulti resolve-type #'dispatch :default ::default)
 
 (defmethod resolve-type ::default [x]
   (println (error-message x)))
@@ -63,3 +75,5 @@
 (defmethod resolve-type 'clojure.core/sequential? [_] nil)
 (defmethod resolve-type 'clojure.core/ratio? [_] :ratio)
 (defmethod resolve-type 'clojure.core/bytes? [_] nil)
+
+(defmethod resolve-type 'clojure.spec/keys [_] :map)

--- a/src/spec_tools/types.cljc
+++ b/src/spec_tools/types.cljc
@@ -33,7 +33,7 @@
 
 (defmethod resolve-type 'clojure.core/any? [_] nil)
 (defmethod resolve-type 'clojure.core/some? [_] nil)
-(defmethod resolve-type 'clojure.core/number? [_] nil)
+(defmethod resolve-type 'clojure.core/number? [_] :double)
 (defmethod resolve-type 'clojure.core/integer? [_] :long)
 (defmethod resolve-type 'clojure.core/int? [_] :long)
 (defmethod resolve-type 'clojure.core/pos-int? [_] :long)

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -44,17 +44,17 @@
         (is (= ['spec-tools.core/spec
                 #?(:clj  'clojure.core/integer?
                    :cljs 'cljs.core/integer?)
-                {:hint :long}] (s/form my-integer?)))
-        (is (= ['spec 'integer? {:hint :long}] (s/describe my-integer?))))
+                {:type :long}] (s/form my-integer?)))
+        (is (= ['spec 'integer? {:type :long}] (s/describe my-integer?))))
 
       (testing "type resolution"
         (is (= (st/spec integer?)
-               (st/spec integer? {:hint :long})
+               (st/spec integer? {:type :long})
                (st/typed-spec :long integer?))))
 
       (testing "serialization"
-        (let [spec (st/spec integer? {:description "cool", :hint ::integer})]
-          (is (= `(st/spec integer? {:description "cool", :hint ::integer})
+        (let [spec (st/spec integer? {:description "cool", :type ::integer})]
+          (is (= `(st/spec integer? {:description "cool", :type ::integer})
                  (s/form spec)
                  (st/deserialize (st/serialize spec))))))
 
@@ -67,7 +67,7 @@
       (is (= "kikka" (:description spec)))
       (is (true? (s/valid? spec 1)))
       (is (false? (s/valid? spec "1")))
-      (is (= `(st/spec integer? {:description "kikka", :hint nil})
+      (is (= `(st/spec integer? {:description "kikka", :type nil})
              (st/deserialize (st/serialize spec))
              (s/form spec))))))
 
@@ -132,7 +132,7 @@
       (is (= {:height 200, :weight 80}
              (st/conform ::person person {:map conform/map->strip-extra-keys}))))))
 
-(s/def ::human (st/spec (s/keys :req-un [::height ::weight]) {:hint ::human}))
+(s/def ::human (st/spec (s/keys :req-un [::height ::weight]) {:type ::human}))
 
 (defn bmi [{:keys [height weight]}]
   (let [h (/ height 100)]

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -130,7 +130,7 @@
 
     (testing "stripping extra keys"
       (is (= {:height 200, :weight 80}
-             (st/conform ::person person {:map conform/map->strip-extra-keys}))))))
+             (st/conform ::person person {:map conform/strip-extra-keys}))))))
 
 (s/def ::human (st/spec (s/keys :req-un [::height ::weight]) {:type ::human}))
 

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer [deftest testing is]]
             [clojure.spec :as s]
             [spec-tools.core :as st]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [spec-tools.conform :as conform]))
 
 (s/def ::age (s/and st/integer? #(> % 10)))
 (s/def ::over-a-million (s/and st/int? #(> % 1000000)))
@@ -11,6 +12,17 @@
 (s/def ::truth st/boolean?)
 (s/def ::uuid st/uuid?)
 (s/def ::birthdate st/inst?)
+
+(deftest extract-extra-info-test
+  (testing "keys are extracted from keys-specs"
+    (let [spec (st/spec
+                 (s/keys
+                   :req [::age]
+                   :opt [::lat]
+                   :req-un [::uuid]
+                   :opt-un [::truth]))]
+      (is (= #{::age ::lat :uuid :truth}
+             (:keys spec))))))
 
 (deftest specs-test
   (let [my-integer? (st/spec integer?)]
@@ -104,25 +116,41 @@
 
 (s/def ::height integer?)
 (s/def ::weight integer?)
-(s/def ::person (st/typed-spec ::human (s/keys :req-un [::height ::weight])))
+(s/def ::person (st/spec (s/keys :req-un [::height ::weight])))
+
+(st/spec (s/keys :req-un [::height ::weight]))
+
+(deftest map-specs-test
+  (let [person {:height 200, :weight 80, :age 36}]
+
+    (testing "conform"
+      (is (= {:height 200, :weight 80, :age 36}
+             (s/conform ::person person)
+             (st/conform ::person person))))
+
+    (testing "stripping extra keys"
+      (is (= {:height 200, :weight 80}
+             (st/conform ::person person {:map conform/map->strip-extra-keys}))))))
+
+(s/def ::human (st/spec (s/keys :req-un [::height ::weight]) {:hint ::human}))
 
 (defn bmi [{:keys [height weight]}]
   (let [h (/ height 100)]
     (double (/ weight (* h h)))))
 
-(deftest map-specs-test
+(deftest custom-map-specs-test
   (let [person {:height 200, :weight 80}
         bmi-conformer (fn [_ human]
                         (assoc human :bmi (bmi human)))]
 
     (testing "conform"
       (is (= {:height 200, :weight 80}
-             (s/conform ::person person)
-             (st/conform ::person person))))
+             (s/conform ::human person)
+             (st/conform ::human person))))
 
     (testing "bmi-conforming"
       (is (= {:height 200, :weight 80, :bmi 20.0}
-             (st/conform ::person person {::human bmi-conformer}))))))
+             (st/conform ::human person {::human bmi-conformer}))))))
 
 (deftest unform-test
   (let [unform-conform #(s/unform %1 (st/conform %1 %2 st/string-conformers))]

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -13,7 +13,7 @@
 (s/def ::birthdate st/inst?)
 
 (deftest specs-test
-  (let [my-integer? (st/spec ::st/long integer?)]
+  (let [my-integer? (st/spec :long integer?)]
     (testing "work as predicates"
       (is (true? (my-integer? 1)))
       (is (false? (my-integer? "1"))))
@@ -29,10 +29,10 @@
 
       (testing "fully qualifed predicate symbol is returned with s/form"
         (is (= ['spec-tools.core/spec
-                ::st/long
+                :long
                 #?(:clj  'clojure.core/integer?
                    :cljs 'cljs.core/integer?)] (s/form my-integer?)))
-        (is (= ['spec ::st/long 'integer?] (s/describe my-integer?))))
+        (is (= ['spec :long 'integer?] (s/describe my-integer?))))
 
       (testing "serialization"
         (let [spec (st/spec ::integer clojure.core/integer? {:description "cool"})]
@@ -136,7 +136,7 @@
 (deftest extending-test
   (let [my-conformations (-> st/string-conformers
                              (assoc
-                               ::st/keyword
+                               :keyword
                                (fn [_ value]
                                  (-> value
                                      str/upper-case


### PR DESCRIPTION
* `:hint` is resolved automatically, based on a multimethod `spec-tools.types/resolve-type` (fixes https://github.com/metosin/spec-tools/issues/25)
* `:hint`values are now unqualified. KISS.
* `spec` has now simpler syntax, `:hint` is just a extra props (fixes https://github.com/metosin/spec-tools/issues/23)
* `typed-spec` for concise specs with types: `(st/typed-spec :long #(> % 10))`
* all core-predicates have now a Spec (fixes https://github.com/metosin/spec-tools/issues/1)
* `spec-tools.convert` is now `spec-tools.conform`. first arg is the spec-record, not the pred
* `:hint` => `:type`. It's real.
* key-sets are extracted from `keys` specs on creation
  * `spec-tools.convert/map->strip-extra-keys` to strip extra keys away. 

```clj
(defn map->strip-extra-keys [{:keys [keys pred]} x]
  (if (map? x)
    (s/conform pred (select-keys x keys))
    x))
```
