### PR TITLE
0.1.0 final tunings

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For most clojure core predicates, the `:spec/type` can be resolved automatically
 The `:spec/type` enabled the [dynamic conforming](#dynamic-conforming), making Specs great for
 runtime system border validation.
 
-### Out-of-the-box Spec Records
+### Predefined Spec Records
 
 Most/all `clojure.core` predicates have a Spec-wrapped version in the `spec-tools.core`:
 * `any?`, `some?`, `number?`, `integer?`, `int?`, `pos-int?`, `neg-int?`, `nat-int?`,
@@ -111,7 +111,7 @@ Can be added via `:spec/reason`:
 
 To use specs over different wire formats (like JSON), spec values need to conformed selectively
 at runtime. Spec Records always have an dynamic conformer attached to it. By default, it does
-nothing extra. Binding a dynamic var `spec-tools.core/*conformers*` with a function of
+nothing. Binding a dynamic var `spec-tools.core/*conformers*` with a function of
 `spec/type => spec-conformer` will cause the Spec to be conformed at runtime with the selected
 spec-conformer.
 
@@ -294,7 +294,7 @@ Status: waiting for next (current: alpha-14) `clojure.spec` version for the form
 ;               "name" {:type "string"},
 ;               "likes" {:type "object"
 ;                        :additionalProperties {:type "boolean"}},
-;               "languages" {:type "array", :items {:type "string"}},
+;               "languages" {:type "array", :items {:type "string"}, :uniqueItems true},
 ;               "address" {:type "object",
 ;                          :properties {"street" {:type "string"}
 ;                                       "zip" {:type "string"}},

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Clojure Spec is implemented using reified protocols. This makes extending curren
 | `:spec/type`    | Type hint of the Spec, mostly auto-resolved. Used in runtime conformation           |
 | `:spec/reason`  | Value is added to `s/explain-data` problems under key `:reason`                     |
 | `:spec/gen`     | Generator function for the Spec (set via `s/with-gen`)                              |
-| `:spec/keys`    | Set of map keys that the spec defines. Extracted from `s/keys` Specs                |
+| `:spec/keys`    | Set of map keys that the spec defines. Extracted from `s/keys` Specs.               |
+| `:spec/form`    | The underlying spec form.                                                              |
+| `:pred`         | The underlying spec predicate.                                                      |
 | `:name`         | Name of the spec. Contributes to (openapi-)docs                                     |
 | `:description`  | Description of the spec. Contributes to (openapi-)docs                              |
 | `:openapi/...`  | Extra data that is merged with unqualifed keys into openapi-docs                    |

--- a/project.clj
+++ b/project.clj
@@ -17,10 +17,10 @@
                              [lein-cloverage "1.0.9"]]
                    :jvm-opts ^:replace ["-server"]
                    ;:global-vars {*warn-on-reflection* true}
-                   :dependencies [[org.clojure/clojure "1.9.0-alpha14"]
+                   :dependencies [[org.clojure/clojure "1.9.0-alpha15"]
                                   [org.clojure/clojurescript "1.9.456"]
                                   [criterium "0.4.4"]
-                                  [prismatic/schema "1.1.3"]
+                                  [prismatic/schema "1.1.4"]
                                   [org.clojure/test.check "0.9.0"]
                                   [org.clojure/tools.namespace "0.2.11"]
                                   [com.gfredericks/test.chuck "0.2.7"]
@@ -44,5 +44,5 @@
                         :compiler {:output-to "target/node_out/test.js"
                                    :output-dir "target/node_out"
                                    :main spec-tools.doo-runner
-                                   :optimizations :none 
+                                   :optimizations :none
                                    :target :nodejs}}]})

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -148,8 +148,8 @@
     x)
   (explain* [this path via in x]
     (let [problems (if (s/spec? pred)
-                     (s/explain* pred path via in x)
-                     (when (= invalid (if (and (fn? pred) (pred x)) x invalid))
+                     (s/explain* pred path via in (s/conform* this x))
+                     (when (= invalid (if (and (fn? pred) (pred (s/conform* this x))) x invalid))
                        [{:path path
                          :pred (s/abbrev (:spec/form this))
                          :val x

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -226,7 +226,7 @@
       (ex-info
         "only single maps allowed in nested vectors"
         {:k n :v v}))
-    `(s/coll-of ~(coll-spec-fn env n (first v)) :into [])))
+    `(spec (s/coll-of ~(coll-spec-fn env n (first v)) :into []))))
 
 (defn- -set [env n v]
   (if-not (= 1 (count v))
@@ -234,7 +234,7 @@
       (ex-info
         "only single maps allowed in nested sets"
         {:k n :v v}))
-    `(s/coll-of ~(coll-spec-fn env n (first v)) :into #{})))
+    `(spec (s/coll-of ~(coll-spec-fn env n (first v)) :into #{}))))
 
 #?(:clj
    (defn- -map [env n m]
@@ -252,7 +252,7 @@
                                              (let [resolved (resolve (first k))]
                                                (#{resolved-opt resolved-req} resolved)))))
                                   k)))]
-         `(s/map-of ~key-spec ~(coll-spec-fn env n (first (vals m))))
+         `(spec (s/map-of ~key-spec ~(coll-spec-fn env n (first (vals m)))))
          ;; keyword keys
          (let [m (reduce-kv
                    (fn [acc k v]
@@ -285,6 +285,7 @@
                   (clojure.core/set? m) -set)]
        (f env n m)
        `~m)))
+
 #?(:clj
    (defmacro coll-spec [n m]
      (coll-spec-fn &env n m)))

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -266,21 +266,23 @@
 
 #?(:clj (declare ^:private coll-spec-fn))
 
-(defn- -vector [env n v]
-  (if-not (= 1 (count v))
-    (throw
-      (ex-info
-        "only single maps allowed in nested vectors"
-        {:k n :v v}))
-    `(spec (s/coll-of ~(coll-spec-fn env n (first v)) :into []))))
+#?(:clj
+   (defn- -vector [env n v]
+     (if-not (= 1 (count v))
+       (throw
+         (ex-info
+           "only single maps allowed in nested vectors"
+           {:k n :v v}))
+       `(spec (s/coll-of ~(coll-spec-fn env n (first v)) :into [])))))
 
-(defn- -set [env n v]
-  (if-not (= 1 (count v))
-    (throw
-      (ex-info
-        "only single maps allowed in nested sets"
-        {:k n :v v}))
-    `(spec (s/coll-of ~(coll-spec-fn env n (first v)) :into #{}))))
+#?(:clj
+   (defn- -set [env n v]
+     (if-not (= 1 (count v))
+       (throw
+         (ex-info
+           "only single maps allowed in nested sets"
+           {:k n :v v}))
+       `(spec (s/coll-of ~(coll-spec-fn env n (first v)) :into #{})))))
 
 #?(:clj
    (defn- -map [env n m]

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -225,10 +225,16 @@
                (:spec/type m))]
     (map->Spec (merge m info {:spec/form form, :spec/type type}))))
 
+(defn- extract-pred-and-info [x]
+  (if (clojure.core/map? x)
+    [(:pred x) (dissoc x :pred)]
+    [x {}]))
+
 #?(:clj
    (defmacro spec
-     ([pred]
-      `(spec ~pred {}))
+     ([pred-or-info]
+      (let [[pred info] (extract-pred-and-info pred-or-info)]
+        `(spec ~pred ~info)))
      ([pred info]
       (if (impl/in-cljs? &env)
         `(let [info# ~info
@@ -251,8 +257,12 @@
                 :pred ~pred})))))))
 
 #?(:clj
-   (defmacro doc [pred info]
-     `(spec ~pred (merge ~info {:spec/type nil}))))
+   (defmacro doc
+     ([pred-or-info]
+      (let [[pred info] (extract-pred-and-info pred-or-info)]
+        `(doc ~pred ~info)))
+     ([pred info]
+      `(spec ~pred (merge ~info {:spec/type nil})))))
 
 ;;
 ;; Map Spec

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -95,6 +95,22 @@
    (binding [*conformers* conformers]
      (s/conform spec value))))
 
+(defn explain
+  ([spec value]
+   (binding [*conformers* nil]
+     (s/explain spec value)))
+  ([spec value conformers]
+   (binding [*conformers* conformers]
+     (s/explain spec value))))
+
+(defn explain-data
+  ([spec value]
+   (binding [*conformers* nil]
+     (s/explain-data spec value)))
+  ([spec value conformers]
+   (binding [*conformers* conformers]
+     (s/explain-data spec value))))
+
 ;;
 ;; Spec Record
 ;;
@@ -135,9 +151,9 @@
                      (s/explain* pred path via in x)
                      (when (= invalid (if (and (fn? pred) (pred x)) x invalid))
                        [{:path path
-          :pred (s/abbrev (:spec/form this))
-          :val x
-          :via via
+                         :pred (s/abbrev (:spec/form this))
+                         :val x
+                         :via via
                          :in in}]))
           spec-reason (:spec/reason this)
           with-reason (fn [{:keys [reason] :as problem}]

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -102,6 +102,13 @@
 (defn- extra-spec-map [t]
   (dissoc t :spec/form :pred))
 
+(defn- fail-on-invoke [spec]
+  (throw
+    (ex-info
+      (str
+        "Can't invoke spec with a non-function predicate: " spec)
+      {:spec spec})))
+
 (defrecord Spec [pred]
   #?@(:clj
       [s/Specize
@@ -149,8 +156,8 @@
     (let [info (extra-spec-map this)]
       `(spec ~(:spec/form this) ~info)))
   IFn
-  #?(:clj  (invoke [_ x] (pred x))
-     :cljs (-invoke [_ x] (pred x))))
+  #?(:clj  (invoke [this x] (if (fn? pred) (pred x) (fail-on-invoke this)))
+     :cljs (-invoke [this x] (if (fn? pred) (pred x) (fail-on-invoke this)))))
 
 #?(:clj
    (defmethod print-method Spec

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -108,6 +108,24 @@
    (binding [*conformers* conformers]
      (s/conform spec value))))
 
+(defn conform!
+  ([spec value]
+   (conform! spec value nil))
+  ([spec value conformers]
+   (binding [*conformers* conformers]
+     (let [conformed (s/conform spec value)]
+       (if-not (= conformed invalid)
+         conformed
+         (let [problems (s/explain-data spec value)]
+           (throw
+             (ex-info
+               "Spec conform error"
+               (merge
+                 problems
+                 {:type :spec/problems
+                  :spec spec
+                  :value value})))))))))
+
 ;;
 ;; Spec Record
 ;;

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -184,6 +184,8 @@
                       (if (:spec/type t) (select-keys t [:spec/type]))
                       (extra-spec-map t))))))
 
+(defn spec? [x]
+  (if (instance? Spec x) x))
 
 ;; TODO: use http://dev.clojure.org/jira/browse/CLJ-2112
 (defn- extract-extra-info [form]

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -224,13 +224,6 @@
    (defmacro doc [pred info]
      `(spec ~pred (merge ~info {:spec/type nil}))))
 
-#?(:clj
-   (defmacro typed-spec
-     ([type pred]
-      `(spec ~pred {:spec/type ~type}))
-     ([type pred info]
-      `(spec ~pred (merge ~info {:spec/type ~type})))))
-
 ;;
 ;; Map Spec
 ;;

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -275,7 +275,7 @@
            `(do
               ~@(for [[k v] defs]
                   `(s/def ~k ~v))
-              (s/keys ~@margs)))))))
+              (spec (s/keys ~@margs))))))))
 
 #?(:clj
    (defn- coll-spec-fn [env n m]

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -87,29 +87,26 @@
      :nil conform/string->nil
      :string nil}))
 
-(defn conform
-  ([spec value]
-   (binding [*conformers* nil]
-     (s/conform spec value)))
-  ([spec value conformers]
-   (binding [*conformers* conformers]
-     (s/conform spec value))))
-
 (defn explain
   ([spec value]
-   (binding [*conformers* nil]
-     (s/explain spec value)))
+   (explain spec value nil))
   ([spec value conformers]
    (binding [*conformers* conformers]
      (s/explain spec value))))
 
 (defn explain-data
   ([spec value]
-   (binding [*conformers* nil]
-     (s/explain-data spec value)))
+   (explain-data spec value nil))
   ([spec value conformers]
    (binding [*conformers* conformers]
      (s/explain-data spec value))))
+
+(defn conform
+  ([spec value]
+   (conform spec value nil))
+  ([spec value conformers]
+   (binding [*conformers* conformers]
+     (s/conform spec value))))
 
 ;;
 ;; Spec Record

--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -215,26 +215,22 @@
     (if (is-map-of? spec)
       {:type "object" :additionalProperties (get-in (unwrap children) [:items 1])}
       (case type
-        :map {:type "object", :additionalProperties (to-json pred)}
-        :set {:type "array", :uniqueItems true, :items (to-json pred)}
-        :vector {:type "array", :items (to-json pred)}))))
+        :map {:type "object", :additionalProperties (unwrap children)}
+        :set {:type "array", :uniqueItems true, :items (unwrap children)}
+        :vector {:type "array", :items (unwrap children)}))))
 
 ; every-ks
 
 ; coll-of
-(defmethod accept-spec 'clojure.spec/coll-of [dispatch spec children]
-  (let [form (s/form spec)
-        pred (second form)
-        type (types/resolve-type form)]
-    (case type
-      :map {:type "object", :additionalProperties (to-json pred)}
-      :set {:type "array", :uniqueItems true, :items (to-json pred)}
-      :vector {:type "array", :items (to-json pred)})))
-
 ; map-of
-(defmethod accept-spec 'clojure.spec/map-of [dispatch spec children]
-  (let [[_ _ v] (s/form spec)]
-    {:type "object" :additionalProperties (to-json v)}))
+(defmethod accept-spec :map-of [dispatch spec children]
+  {:type "object", :additionalProperties (unwrap children)})
+
+(defmethod accept-spec :set-of [dispatch spec children]
+  {:type "array", :items (unwrap children), :uniqueItems true})
+
+(defmethod accept-spec :vector-of [dispatch spec children]
+  {:type "array", :items (unwrap children)})
 
 ; *
 (defmethod accept-spec 'clojure.spec/* [dispatch spec children]

--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -223,13 +223,13 @@
 
 ; coll-of
 ; map-of
-(defmethod accept-spec :map-of [dispatch spec children]
+(defmethod accept-spec ::visitor/map-of [dispatch spec children]
   {:type "object", :additionalProperties (unwrap children)})
 
-(defmethod accept-spec :set-of [dispatch spec children]
+(defmethod accept-spec ::visitor/set-of [dispatch spec children]
   {:type "array", :items (unwrap children), :uniqueItems true})
 
-(defmethod accept-spec :vector-of [dispatch spec children]
+(defmethod accept-spec ::visitor/vector-of [dispatch spec children]
   {:type "array", :items (unwrap children)})
 
 ; *

--- a/src/spec_tools/types.cljc
+++ b/src/spec_tools/types.cljc
@@ -77,3 +77,12 @@
 (defmethod resolve-type 'clojure.core/bytes? [_] nil)
 
 (defmethod resolve-type 'clojure.spec/keys [_] :map)
+(defmethod resolve-type 'clojure.spec/map-of [_] :map)
+
+(defmethod resolve-type 'clojure.spec/coll-of [x]
+  (let [{:keys [into]} (apply hash-map (drop 2 x))]
+    (cond
+      (map? into) :map
+      (set? into) :set
+      :else :vector)))
+

--- a/src/spec_tools/types.cljc
+++ b/src/spec_tools/types.cljc
@@ -31,6 +31,22 @@
     (resolve-type x)
     (throw (ex-info (error-message x) {:spec x}))))
 
+(defn- all-types []
+  {:long
+   :double
+   :boolean
+   :string
+   :keyword
+   :symbol
+   :uuid
+   :uri
+   :bigdec
+   :date
+   :ratio
+   :map
+   :set
+   :vector})
+
 (defmethod resolve-type 'clojure.core/any? [_] nil)
 (defmethod resolve-type 'clojure.core/some? [_] nil)
 (defmethod resolve-type 'clojure.core/number? [_] :double)

--- a/src/spec_tools/types.cljc
+++ b/src/spec_tools/types.cljc
@@ -102,3 +102,4 @@
       (set? into) :set
       :else :vector)))
 
+(defmethod resolve-type 'clojure.spec/and [x] nil)

--- a/src/spec_tools/types.cljc
+++ b/src/spec_tools/types.cljc
@@ -1,11 +1,6 @@
 (ns spec-tools.types
-  (:require [spec-tools.impl :as impl]))
-
-(defn- error-message [x]
-  (str
-    "Can't resolve type of a spec: '" x "'. "
-    "You need to provide a `:hint` for the spec or "
-    "add a dispatch function for `spec-tools.types/resolve-type`."))
+  (:require [spec-tools.impl :as impl]
+            [clojure.string :as str]))
 
 (defn- dispatch [x]
   (cond
@@ -20,6 +15,13 @@
 
     ;; default
     :else x))
+
+(defn- error-message [x]
+  (str
+    "Can't resolve type for dispatch value `" (dispatch x) "`. "
+    "Provide a `:hint` for the spec or add a dispatch "
+    "function for `spec-tools.types/resolve-type`. Spec: "
+    (str/replace (str x) #"\n" " ") "\n"))
 
 (defmulti resolve-type #'dispatch :default ::default)
 
@@ -92,9 +94,28 @@
 (defmethod resolve-type 'clojure.core/ratio? [_] :ratio)
 (defmethod resolve-type 'clojure.core/bytes? [_] nil)
 
+; keys
 (defmethod resolve-type 'clojure.spec/keys [_] :map)
-(defmethod resolve-type 'clojure.spec/map-of [_] :map)
 
+; or
+(defmethod resolve-type 'clojure.spec/or [x] nil)
+
+; and
+(defmethod resolve-type 'clojure.spec/and [x] nil)
+
+; merge
+
+; every
+(defmethod resolve-type 'clojure.spec/every [x]
+  (let [{:keys [into]} (apply hash-map (drop 2 x))]
+    (cond
+      (map? into) :map
+      (set? into) :set
+      :else :vector)))
+
+; every-ks
+
+; coll-of
 (defmethod resolve-type 'clojure.spec/coll-of [x]
   (let [{:keys [into]} (apply hash-map (drop 2 x))]
     (cond
@@ -102,4 +123,15 @@
       (set? into) :set
       :else :vector)))
 
-(defmethod resolve-type 'clojure.spec/and [x] nil)
+; map-of
+(defmethod resolve-type 'clojure.spec/map-of [_] :map)
+
+; *
+; +
+; ?
+; alt
+; cat
+; &
+; tuple
+; keys*
+; nilable

--- a/src/spec_tools/visitor.cljc
+++ b/src/spec_tools/visitor.cljc
@@ -87,16 +87,16 @@
 
 (defmethod visit 'clojure.spec/map-of [spec accept]
   (let [[_ _ v] (s/form spec)]
-    (accept :map-of spec [(visit v accept)])))
+    (accept ::map-of spec [(visit v accept)])))
 
 (defmethod visit 'clojure.spec/coll-of [spec accept]
   (let [form (s/form spec)
         pred (second form)
         type (types/resolve-type form)
         dispatch (case type
-                   :map :map-of
-                   :set :set-of
-                   :vector :vector-of)]
+                   :map ::map-of
+                   :set ::set-of
+                   :vector ::vector-of)]
     (accept dispatch spec [(visit pred accept)])))
 
 (defmethod visit 'spec-tools.core/spec [spec accept]

--- a/src/spec_tools/visitor.cljc
+++ b/src/spec_tools/visitor.cljc
@@ -1,6 +1,7 @@
 (ns spec-tools.visitor
   "Tools for walking spec definitions."
-  (:require [clojure.spec :as s]))
+  (:require [clojure.spec :as s]
+            [spec-tools.types :as types]))
 
 (defn strip-fn-if-needed [form]
   (let [head (first form)]
@@ -83,6 +84,20 @@
 (defmethod visit 'clojure.spec/nilable [spec accept]
   (let [[_ inner-spec] (s/form spec)]
     (accept 'clojure.spec/nilable spec [(visit inner-spec accept)])))
+
+(defmethod visit 'clojure.spec/map-of [spec accept]
+  (let [[_ _ v] (s/form spec)]
+    (accept :map-of spec [(visit v accept)])))
+
+(defmethod visit 'clojure.spec/coll-of [spec accept]
+  (let [form (s/form spec)
+        pred (second form)
+        type (types/resolve-type form)
+        dispatch (case type
+                   :map :map-of
+                   :set :set-of
+                   :vector :vector-of)]
+    (accept dispatch spec [(visit pred accept)])))
 
 (defmethod visit 'spec-tools.core/spec [spec accept]
   ;; TODO: we might get a reference to a spec (why?)

--- a/src/spec_tools/visitor.cljc
+++ b/src/spec_tools/visitor.cljc
@@ -1,7 +1,6 @@
 (ns spec-tools.visitor
   "Tools for walking spec definitions."
-  (:require [clojure.spec :as s]
-            [clojure.set :as set]))
+  (:require [clojure.spec :as s]))
 
 (defn strip-fn-if-needed [form]
   (let [head (first form)]
@@ -84,6 +83,11 @@
 (defmethod visit 'clojure.spec/nilable [spec accept]
   (let [[_ inner-spec] (s/form spec)]
     (accept 'clojure.spec/nilable spec [(visit inner-spec accept)])))
+
+(defmethod visit 'spec-tools.core/spec [spec accept]
+  ;; TODO: we might get a reference to a spec (why?)
+  (let [spec (or (s/get-spec spec) spec)]
+    (visit (:pred spec) accept)))
 
 (defmethod visit ::default [spec accept]
   (accept (spec-dispatch spec accept) spec nil))

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -145,7 +145,7 @@
 (deftest explain-tests
   (testing "without conforming"
     (is (= st/invalid (st/conform st/int? "12")))
-    (is (= {::s/problems [{:path [], :pred int?, :val "12", :via [], :in []}]}
+    (is (= {::s/problems [{:path [], :pred 'int?, :val "12", :via [], :in []}]}
            (st/explain-data st/int? "12"))))
   (testing "with conforming"
     (is (= 12 (st/conform st/int? "12" st/string-conformers)))

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -24,6 +24,16 @@
       (is (= #{::age ::lat :uuid :truth}
              (:spec/keys spec))))))
 
+(deftest spec?-test
+  (testing "spec"
+    (let [spec (s/spec integer?)]
+      (is (= spec (s/spec? spec)))
+      (is (nil? (st/spec? spec)))))
+  (testing "Spec"
+    (let [spec (st/spec integer?)]
+      (is (= spec (s/spec? spec)))
+      (is (= spec (st/spec? spec))))))
+
 (deftest specs-test
   (let [my-integer? (st/spec integer?)]
 

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -248,12 +248,12 @@
                               :zip string?}})
           s-keys (st/spec
                    (s/keys
-                   :req [::id ::age]
-                   :req-un [:spec-tools.core-test$my-map/boss
-                            :spec-tools.core-test$my-map/name
-                            :spec-tools.core-test$my-map/languages
-                            :spec-tools.core-test$my-map/orders
-                            :spec-tools.core-test$my-map/address]
+                     :req [::id ::age]
+                     :req-un [:spec-tools.core-test$my-map/boss
+                              :spec-tools.core-test$my-map/name
+                              :spec-tools.core-test$my-map/languages
+                              :spec-tools.core-test$my-map/orders
+                              :spec-tools.core-test$my-map/address]
                      :opt-un [:spec-tools.core-test$my-map/description]))]
 
       (testing "normal keys-spec-spec is generated"

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -140,7 +140,20 @@
         (is (= #inst "2014-02-18T18:25:37Z"
                (conform ::birthdate "2014-02-18T18:25:37Z")))))))
 
-(st/explain-data st/int? "12")
+(deftest conform!-test
+  (testing "suceess"
+    (is (= 12 (st/conform! ::age "12" st/string-conformers))))
+  (testing "failing"
+    (is (thrown? RuntimeException (st/conform! ::age "12")))
+    (try
+      (st/conform! ::age "12")
+      (catch Exception e
+        (let [data (ex-data e)]
+          (is (= {:type :spec/problems
+                  :clojure.spec/problems [{:path [], :pred 'integer?, :val "12", :via [::age], :in []}]
+                  :spec :spec-tools.core-test/age
+                  :value "12"}
+                 data)))))))
 
 (deftest explain-tests
   (testing "without conforming"

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -43,7 +43,7 @@
 
     (testing "wrapped spec does not work as a predicate"
       (let [my-spec (st/spec (s/keys :req [::age]))]
-        (is (thrown? RuntimeException (my-spec {::age 20})))))
+        (is (thrown? #?(:clj Exception, :cljs js/Error) (my-spec {::age 20})))))
 
     (testing "adding info"
       (let [info {:description "desc"
@@ -144,10 +144,10 @@
   (testing "suceess"
     (is (= 12 (st/conform! ::age "12" st/string-conformers))))
   (testing "failing"
-    (is (thrown? RuntimeException (st/conform! ::age "12")))
+    (is (thrown? #?(:clj Exception, :cljs js/Error) (st/conform! ::age "12")))
     (try
       (st/conform! ::age "12")
-      (catch Exception e
+      (catch #?(:clj Exception, :cljs js/Error) e
         (let [data (ex-data e)]
           (is (= {:type :spec/problems
                   :clojure.spec/problems [{:path [], :pred 'integer?, :val "12", :via [::age], :in []}]

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -27,9 +27,13 @@
 (deftest specs-test
   (let [my-integer? (st/spec integer?)]
 
-    (testing "work as predicates"
+    (testing "wrapped predicate work as a predicate"
       (is (true? (my-integer? 1)))
       (is (false? (my-integer? "1"))))
+
+    (testing "wrapped spec does not work as a predicate"
+      (let [my-spec (st/spec (s/keys :req [::age]))]
+        (is (thrown? RuntimeException (my-spec {::age 20})))))
 
     (testing "adding info"
       (let [info {:description "desc"

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -37,6 +37,10 @@
 (deftest specs-test
   (let [my-integer? (st/spec integer?)]
 
+    (testing "creation"
+      (is (= (st/spec integer?)
+             (st/spec {:pred integer?}))))
+
     (testing "wrapped predicate work as a predicate"
       (is (true? (my-integer? 1)))
       (is (false? (my-integer? "1"))))
@@ -75,6 +79,12 @@
         (is (seq? (s/exercise my-integer?)))))))
 
 (deftest doc-test
+
+  (testing "creation"
+    (is (= (st/doc integer? {:description "kikka"})
+           (st/doc {:pred integer?, :description "kikka"})
+           (st/spec {:pred integer?, :description "kikka", :spec/type nil}))))
+
   (testing "just docs, #12"
     (let [spec (st/doc integer? {:description "kikka"})]
       (is (= "kikka" (:description spec)))

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -49,8 +49,7 @@
 
       (testing "type resolution"
         (is (= (st/spec integer?)
-               (st/spec integer? {:spec/type :long})
-               (st/typed-spec :long integer?))))
+               (st/spec integer? {:spec/type :long}))))
 
       (testing "serialization"
         (let [spec (st/spec integer? {:description "cool", :spec/type ::integer})]

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -76,13 +76,15 @@
 
 (deftest reason-test
   (let [expected-problem {:path [] :pred 'pos-int?, :val -1, :via [], :in []}]
-    (testing "normal explain-data"
+    (testing "explain-data"
       (is (= #?(:clj  #:clojure.spec{:problems [expected-problem]}
                 :cljs #:cljs.spec{:problems [expected-problem]})
+             (st/explain-data (st/spec pos-int?) -1)
              (s/explain-data (st/spec pos-int?) -1))))
     (testing "explain-data with reason"
       (is (= #?(:clj  #:clojure.spec{:problems [(assoc expected-problem :reason "positive")]}
                 :cljs #:cljs.spec{:problems [(assoc expected-problem :reason "positive")]})
+             (st/explain-data (st/spec pos-int? {:spec/reason "positive"}) -1)
              (s/explain-data (st/spec pos-int? {:spec/reason "positive"}) -1))))))
 
 (deftest spec-tools-conform-test
@@ -127,6 +129,18 @@
                (conform ::birthdate "2014-02-18T18:25:37.456Z")))
         (is (= #inst "2014-02-18T18:25:37Z"
                (conform ::birthdate "2014-02-18T18:25:37Z")))))))
+
+(st/explain-data st/int? "12")
+
+(deftest explain-tests
+  (testing "without conforming"
+    (is (= st/invalid (st/conform st/int? "12")))
+    (is (= {::s/problems [{:path [], :pred int?, :val "12", :via [], :in []}]}
+           (st/explain-data st/int? "12"))))
+  (testing "with conforming"
+    (is (= 12 (st/conform st/int? "12" st/string-conformers)))
+    (is (= nil
+           (st/explain-data st/int? "12" st/string-conformers)))))
 
 (s/def ::height integer?)
 (s/def ::weight integer?)

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -100,14 +100,14 @@
 (deftest spec-tools-conform-test
   (testing "in default mode"
     (testing "nothing is conformed"
-      (is (= st/invalid (st/conform ::age "12")))
-      (is (= st/invalid (st/conform ::over-a-million "1234567")))
-      (is (= st/invalid (st/conform ::lat "23.1234")))
-      (is (= st/invalid (st/conform ::language "clojure")))
-      (is (= st/invalid (st/conform ::truth "false")))
-      (is (= st/invalid (st/conform ::uuid "07dbf30f-c99e-4e5d-b76e-5cbdac3b381e")))
-      (is (= st/invalid (st/conform ::birthdate "2014-02-18T18:25:37.456Z")))
-      (is (= st/invalid (st/conform ::birthdate "2014-02-18T18:25:37Z")))))
+      (is (= st/+invalid+ (st/conform ::age "12")))
+      (is (= st/+invalid+ (st/conform ::over-a-million "1234567")))
+      (is (= st/+invalid+ (st/conform ::lat "23.1234")))
+      (is (= st/+invalid+ (st/conform ::language "clojure")))
+      (is (= st/+invalid+ (st/conform ::truth "false")))
+      (is (= st/+invalid+ (st/conform ::uuid "07dbf30f-c99e-4e5d-b76e-5cbdac3b381e")))
+      (is (= st/+invalid+ (st/conform ::birthdate "2014-02-18T18:25:37.456Z")))
+      (is (= st/+invalid+ (st/conform ::birthdate "2014-02-18T18:25:37Z")))))
 
   (testing "string-conformers"
     (let [conform #(st/conform %1 %2 st/string-conformers)]
@@ -127,10 +127,10 @@
   (testing "json-conformers"
     (let [conform #(st/conform %1 %2 st/json-conformers)]
       (testing "some are not conformed"
-        (is (= st/invalid (conform ::age "12")))
-        (is (= st/invalid (conform ::over-a-million "1234567")))
-        (is (= st/invalid (conform ::lat "23.1234")))
-        (is (= st/invalid (conform ::truth "false"))))
+        (is (= st/+invalid+ (conform ::age "12")))
+        (is (= st/+invalid+ (conform ::over-a-million "1234567")))
+        (is (= st/+invalid+ (conform ::lat "23.1234")))
+        (is (= st/+invalid+ (conform ::truth "false"))))
       (testing "some are conformed"
         (is (= :clojure (conform ::language "clojure")))
         (is (= #uuid "07dbf30f-c99e-4e5d-b76e-5cbdac3b381e"
@@ -150,14 +150,14 @@
       (catch #?(:clj Exception, :cljs js/Error) e
         (let [data (ex-data e)]
           (is (= {:type :spec/problems
-                  :clojure.spec/problems [{:path [], :pred 'integer?, :val "12", :via [::age], :in []}]
+                  :problems [{:path [], :pred 'integer?, :val "12", :via [::age], :in []}]
                   :spec :spec-tools.core-test/age
                   :value "12"}
                  data)))))))
 
 (deftest explain-tests
   (testing "without conforming"
-    (is (= st/invalid (st/conform st/int? "12")))
+    (is (= st/+invalid+ (st/conform st/int? "12")))
     (is (= {::s/problems [{:path [], :pred 'int?, :val "12", :via [], :in []}]}
            (st/explain-data st/int? "12"))))
   (testing "with conforming"

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -39,7 +39,8 @@
 
     (testing "creation"
       (is (= (st/spec integer?)
-             (st/spec {:pred integer?}))))
+             (st/spec {:pred integer?})
+             (st/spec integer? {}))))
 
     (testing "wrapped predicate work as a predicate"
       (is (true? (my-integer? 1)))
@@ -83,6 +84,7 @@
   (testing "creation"
     (is (= (st/doc integer? {:description "kikka"})
            (st/doc {:pred integer?, :description "kikka"})
+           (st/doc integer? {:description "kikka"})
            (st/spec {:pred integer?, :description "kikka", :spec/type nil}))))
 
   (testing "just docs, #12"

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -205,16 +205,17 @@
                               :description string?}]
                     :address {:street string?
                               :zip string?}})
-          s-keys (s/keys
+          s-keys (st/spec
+                   (s/keys
                    :req [::id ::age]
                    :req-un [:spec-tools.core-test$my-map/boss
                             :spec-tools.core-test$my-map/name
                             :spec-tools.core-test$my-map/languages
                             :spec-tools.core-test$my-map/orders
                             :spec-tools.core-test$my-map/address]
-                   :opt-un [:spec-tools.core-test$my-map/description])]
+                     :opt-un [:spec-tools.core-test$my-map/description]))]
 
-      (testing "vanilla keys-spec is generated"
+      (testing "normal keys-spec-spec is generated"
         (is (= (s/form s-keys) (s/form st-map))))
       (testing "nested keys are in the registry"
         (let [generated-keys (->> (st/registry #"spec-tools.core-test\$my-map.*") (map first) set)]

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -244,8 +244,17 @@
                               {:id 2, :description "kebab"}]
                      :description "Liisa is a valid boss"
                      :address {:street "Amurinkatu 2"
-                               :zip "33210"}}]
-          (is (true? (s/valid? st-map value)))))))
+                               :zip "33210"}}
+              bloated (-> value
+                          (assoc-in [:KIKKA] true)
+                          (assoc-in [:address :KIKKA] true))]
+
+          (testing "data can be validated"
+            (is (true? (s/valid? st-map value))))
+
+          (testing "map-conforming works recursively"
+            (is (= value
+                   (st/conform st-map bloated {:map conform/strip-extra-keys}))))))))
 
   (testing "top-level vector"
     (is (true?

--- a/test/cljc/spec_tools/json_schema_test.cljc
+++ b/test/cljc/spec_tools/json_schema_test.cljc
@@ -91,7 +91,7 @@
            "age" {:type "integer"}  ; not supporting > yet
            "name" {:type "string"}
            "likes" {:type "object" :additionalProperties {:type "boolean"}}
-           "languages" {:type "array", :items {:type "string"}}
+           "languages" {:type "array", :items {:type "string"}, :uniqueItems true}
            "address" {:type "object"
                       :required ["street" "zip"]
                       :properties {"street" {:type "string"}


### PR DESCRIPTION
*  rename `:form` => `:spec/form` in `Spec`s.
* `st/spec?` - like `clojure.spec/spec?` but checks if they are `Spec`s
* `st/explain`, `st/explain-data`
* `st/conform!` to conform or throw problems via ex-info
* faster `st/coll-spec`s, they returns `spec`s
* remove `st/typed-spec`
* use `alpha-15`
* resolve types & json-schema for `coll-of` & `map-of`
* allow `Specs` to be created with a single (reader-expanded) map: 

```clj
(testing "creation"
  (is (= (st/spec integer?)
         (st/spec {:pred integer?})
         (st/spec integer? {}))))
```

