### PR TITLE
Visit em all

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ A tool to walk over and transform specs using the [Visitor-pattern](https://en.w
 ;                        {:type :map, :keys #{:street :zip}})}
 ```
 
-* **TODO**: Cover all of `clojure.spec`
+**NOTE**: due to [CLJ-2152](http://dev.clojure.org/jira/browse/CLJ-2152), `s/&` & `s/keys*` can't be visited.
 
 ### Generating JSON Schemas
 

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                    :dependencies [[org.clojure/clojure "1.9.0-alpha15"]
                                   [org.clojure/clojurescript "1.9.518"]
                                   [criterium "0.4.4"]
-                                  [prismatic/schema "1.1.4"]
+                                  [prismatic/schema "1.1.5"]
                                   [org.clojure/test.check "0.9.0"]
                                   [org.clojure/tools.namespace "0.2.11"]
                                   [com.gfredericks/test.chuck "0.2.7"]

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                    :jvm-opts ^:replace ["-server"]
                    ;:global-vars {*warn-on-reflection* true}
                    :dependencies [[org.clojure/clojure "1.9.0-alpha15"]
-                                  [org.clojure/clojurescript "1.9.494"]
+                                  [org.clojure/clojurescript "1.9.518"]
                                   [criterium "0.4.4"]
                                   [prismatic/schema "1.1.4"]
                                   [org.clojure/test.check "0.9.0"]

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -149,7 +149,7 @@
           ;; invalid
           +invalid+))))
   (unform* [_ x]
-    x)
+    (s/unform* (s/specize* spec) x))
   (explain* [this path via in x]
     (let [problems (cond
 

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -163,11 +163,16 @@
     x)
   (explain* [this path via in x]
     (let [problems (cond
+
                      (s/spec? spec)
-                     (s/explain* spec path via in (s/conform* this x))
+                     (let [conformed (s/conform* this x)
+                           val (if (= conformed +invalid+) x (s/unform spec conformed))]
+                       (s/explain* spec path via in val))
 
                      (s/regex? spec)
-                     (s/explain* (s/specize* spec) path via in (s/unform spec (s/conform* this x)))
+                     (let [conformed (s/conform* this x)
+                           val (if (= conformed +invalid+) x (s/unform spec conformed))]
+                       (s/explain* (s/specize* spec) path via in val))
 
                      :else
                      (when (= +invalid+ (if (and (fn? spec) (spec (s/conform* this x))) x +invalid+))

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -208,19 +208,13 @@
 
 ;; and's and or's are just flattened
 (defmethod collect-info 'clojure.spec/keys [_ form]
-  (if-let [{:keys [req opt req-un opt-un]} (some->> form (rest) (apply hash-map))]
-    (letfn [(polish [x]
-              (cond
-                (seq? x) (keep polish x)
-                (symbol? x) nil
-                :else x))]
-      {:keys (set
-               (flatten
-                 (concat
-                   (map polish req)
-                   (map polish opt)
-                   (map (comp keyword name) (map polish req-un))
-                   (map (comp keyword name) (map polish opt-un)))))})))
+  (let [{:keys [req opt req-un opt-un]} (some->> form (rest) (apply hash-map))]
+    {:keys (set
+             (flatten
+               (concat
+                 (map impl/polish (concat req opt))
+                 (->> (concat req-un opt-un)
+                      (map (comp keyword name impl/polish))))))}))
 
 (defn extract-extra-info [form]
   (if (seq? form)

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -154,8 +154,8 @@
       ;; there is a dynamic conformer
       (if-let [conform (get *conforming* type)]
         (conform this x)
-        ;; spec predicate
-        (if (s/spec? spec)
+        ;; spec or regex
+        (if (or (s/spec? spec) (s/regex? spec))
           (s/conform spec x)
           ;; invalid
           +invalid+))))

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -51,11 +51,6 @@
         (str "can't coerce to spec: " name-or-spec)
         {:name-or-spec name-or-spec}))))
 
-(defn ^:skip-wiki set-of [value]
-  (s/coll-of
-    value
-    :into #{}))
-
 (defn ^:skip-wiki serialize
   "Writes specs into a string that can be read by the reader.
   TODO: Should optionally write the realated Registry entries."

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -51,16 +51,10 @@
         (str "can't coerce to spec: " name-or-spec)
         {:name-or-spec name-or-spec}))))
 
-(defn ^:skip-wiki eq [value]
-  #{value})
-
 (defn ^:skip-wiki set-of [value]
   (s/coll-of
     value
     :into #{}))
-
-(defn ^:skip-wiki enum [& values]
-  (s/spec (set values)))
 
 (defn ^:skip-wiki serialize
   "Writes specs into a string that can be read by the reader.

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -151,19 +151,10 @@
   (unform* [_ x]
     (s/unform* (s/specize* spec) x))
   (explain* [this path via in x]
-    (let [problems (cond
-
-                     (s/spec? spec)
-                     (let [conformed (s/conform* this x)
-                           val (if (= conformed +invalid+) x (s/unform spec conformed))]
-                       (s/explain* spec path via in val))
-
-                     (s/regex? spec)
+    (let [problems (if (or (s/spec? spec) (s/regex? spec))
                      (let [conformed (s/conform* this x)
                            val (if (= conformed +invalid+) x (s/unform spec conformed))]
                        (s/explain* (s/specize* spec) path via in val))
-
-                     :else
                      (when (= +invalid+ (if (and (fn? spec) (spec (s/conform* this x))) x +invalid+))
                        [{:path path
                          :pred (s/abbrev form)

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -162,8 +162,14 @@
   (unform* [_ x]
     x)
   (explain* [this path via in x]
-    (let [problems (if (s/spec? spec)
+    (let [problems (cond
+                     (s/spec? spec)
                      (s/explain* spec path via in (s/conform* this x))
+
+                     (s/regex? spec)
+                     (s/explain* (s/specize* spec) path via in (s/unform spec (s/conform* this x)))
+
+                     :else
                      (when (= +invalid+ (if (and (fn? spec) (spec (s/conform* this x))) x +invalid+))
                        [{:path path
                          :pred (s/abbrev form)

--- a/src/spec_tools/impl.cljc
+++ b/src/spec_tools/impl.cljc
@@ -56,4 +56,4 @@
 
 (defn extract-keys [form]
   (let [{:keys [req opt req-un opt-un]} (some->> form (rest) (apply hash-map))]
-    (set (flatten (map polish (concat req opt req-un opt-un))))))
+    (flatten (map polish (concat req opt req-un opt-un)))))

--- a/src/spec_tools/impl.cljc
+++ b/src/spec_tools/impl.cljc
@@ -47,3 +47,13 @@
     (symbol? form) (clojure.core/or (->> form (resolve env) cljs-sym) form)
     (sequential? form) (walk/postwalk #(if (symbol? %) (cljs-resolve env %) %) (unfn form))
     :else form))
+
+(defn polish [x]
+  (cond
+    (seq? x) (flatten (keep polish x))
+    (symbol? x) nil
+    :else x))
+
+(defn extract-keys [form]
+  (let [{:keys [req opt req-un opt-un]} (some->> form (rest) (apply hash-map))]
+    (set (flatten (map polish (concat req opt req-un opt-un))))))

--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -189,7 +189,6 @@
     ;; (s/every (s/tuple key-spec value-spec) :into {} ...)
     (and (= pred #?(:clj 'clojure.spec/tuple :cljs 'cljs.spec/tuple)) (= (get kwargs :into)) {})))
 
-; keys
 (defmethod accept-spec 'clojure.spec/keys [dispatch spec children]
   (let [[_ & {:keys [req req-un opt opt-un]}] (s/form spec)
         names (map name (concat req req-un opt opt-un))
@@ -198,17 +197,14 @@
      :properties (zipmap names children)
      :required required}))
 
-; or
 (defmethod accept-spec 'clojure.spec/or [dispatch spec children]
   {:anyOf children})
 
-; and
 (defmethod accept-spec 'clojure.spec/and [dispatch spec children]
   (simplify-all-of {:allOf children}))
 
 ; merge
 
-; every
 (defmethod accept-spec 'clojure.spec/every [dispatch spec children]
   (let [form (s/form spec)
         pred (second form)
@@ -223,8 +219,6 @@
 
 ; every-ks
 
-; coll-of
-; map-of
 (defmethod accept-spec ::visitor/map-of [dispatch spec children]
   {:type "object", :additionalProperties (second children)})
 
@@ -234,32 +228,30 @@
 (defmethod accept-spec ::visitor/vector-of [dispatch spec children]
   {:type "array", :items (unwrap children)})
 
-; *
 (defmethod accept-spec 'clojure.spec/* [dispatch spec children]
   {:type "array" :items (unwrap children)})
 
-; +
 (defmethod accept-spec 'clojure.spec/+ [dispatch spec children]
   {:type "array" :items (unwrap children) :minItems 1})
 
-; ?
 (defmethod accept-spec 'clojure.spec/? [dispatch spec children]
   {:type "array" :items (unwrap children) :minItems 0})
 
-; alt
 (defmethod accept-spec 'clojure.spec/alt [dispatch spec children]
   {:anyOf children})
 
 ; cat
-; &
+(defmethod accept-spec 'clojure.spec/cat [dispatch spec children]
+  {:type "array"
+   :minItems (count children)
+   :maxItems (count children)
+   :items {:anyOf children}})
 
-; tuple
 (defmethod accept-spec 'clojure.spec/tuple [dispatch spec children]
   {:type "array" :items children :minItems (count children)})
 
 ; keys*
 
-; nilable
 (defmethod accept-spec 'clojure.spec/nilable [dispatch spec children]
   {:oneOf [(unwrap children) {:type "null"}]})
 

--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -243,6 +243,9 @@
   {:type "array" :items (unwrap children) :minItems 1})
 
 ; ?
+(defmethod accept-spec 'clojure.spec/? [dispatch spec children]
+  {:type "array" :items (unwrap children) :minItems 0})
+
 ; alt
 (defmethod accept-spec 'clojure.spec/alt [dispatch spec children]
   {:anyOf children})

--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -226,7 +226,7 @@
 ; coll-of
 ; map-of
 (defmethod accept-spec ::visitor/map-of [dispatch spec children]
-  {:type "object", :additionalProperties (unwrap children)})
+  {:type "object", :additionalProperties (second children)})
 
 (defmethod accept-spec ::visitor/set-of [dispatch spec children]
   {:type "array", :items (unwrap children), :uniqueItems true})

--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -240,12 +240,13 @@
 (defmethod accept-spec 'clojure.spec/alt [dispatch spec children]
   {:anyOf children})
 
-; cat
 (defmethod accept-spec 'clojure.spec/cat [dispatch spec children]
   {:type "array"
    :minItems (count children)
    :maxItems (count children)
    :items {:anyOf children}})
+
+; &
 
 (defmethod accept-spec 'clojure.spec/tuple [dispatch spec children]
   {:type "array" :items children :minItems (count children)})

--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -217,7 +217,8 @@
         :set {:type "array", :uniqueItems true, :items (unwrap children)}
         :vector {:type "array", :items (unwrap children)}))))
 
-; every-ks
+(defmethod accept-spec 'clojure.spec/every-kv [dispatch spec children]
+  {:type "object", :additionalProperties (second children)})
 
 (defmethod accept-spec ::visitor/map-of [dispatch spec children]
   {:type "object", :additionalProperties (second children)})

--- a/src/spec_tools/type.cljc
+++ b/src/spec_tools/type.cljc
@@ -89,18 +89,14 @@
 
 (defmethod resolve-type :clojure.spec/unknown [_] nil)
 
-; keys
 (defmethod resolve-type 'clojure.spec/keys [_] :map)
 
-; or
 (defmethod resolve-type 'clojure.spec/or [x] nil)
 
-; and
 (defmethod resolve-type 'clojure.spec/and [x] nil)
 
 ; merge
 
-; every
 (defmethod resolve-type 'clojure.spec/every [x]
   (let [{:keys [into]} (apply hash-map (drop 2 x))]
     (cond
@@ -110,7 +106,6 @@
 
 ; every-ks
 
-; coll-of
 (defmethod resolve-type 'clojure.spec/coll-of [x]
   (let [{:keys [into]} (apply hash-map (drop 2 x))]
     (cond
@@ -118,7 +113,6 @@
       (set? into) :set
       :else :vector)))
 
-; map-of
 (defmethod resolve-type 'clojure.spec/map-of [_] :map)
 
 ; *

--- a/src/spec_tools/visitor.cljc
+++ b/src/spec_tools/visitor.cljc
@@ -175,6 +175,7 @@
       (if (keyword? v)
         (swap! report into (convert-specs! v))
         (when-not (st/spec? v)
-          (eval `(s/def ~k (st/create-spec {:spec ~v})))
-          (swap! report conj k))))
+          (let [s (st/create-spec {:spec v})]
+            (s/def-impl k (s/form s) s)
+            (swap! report conj k)))))
     @report))

--- a/src/spec_tools/visitor.cljc
+++ b/src/spec_tools/visitor.cljc
@@ -108,7 +108,9 @@
   (let [[_ inner-spec] (s/form spec)]
     (accept 'clojure.spec/+ spec [(visit inner-spec accept)])))
 
-;(defmethod visit 'clojure.spec/? [spec accept])
+(defmethod visit 'clojure.spec/? [spec accept]
+  (let [[_ inner-spec] (s/form spec)]
+    (accept 'clojure.spec/? spec [(visit inner-spec accept)])))
 
 (defmethod visit 'clojure.spec/alt [spec accept]
   (let [[_ & {:as inner-spec-map}] (s/form spec)]

--- a/src/spec_tools/visitor.cljc
+++ b/src/spec_tools/visitor.cljc
@@ -2,7 +2,8 @@
   "Tools for walking spec definitions."
   (:require [clojure.spec :as s]
             [spec-tools.core :as st]
-            [spec-tools.type :as type]))
+            [spec-tools.type :as type]
+            [spec-tools.impl :as impl]))
 
 (defn strip-fn-if-needed [form]
   (let [head (first form)]
@@ -67,8 +68,8 @@
   (accept ::set spec (vec (if (keyword? spec) (s/form spec) spec))))
 
 (defmethod visit 'clojure.spec/keys [spec accept]
-  (let [[_ & {:keys [req req-un opt opt-un]}] (s/form spec)]
-    (accept 'clojure.spec/keys spec (mapv #(visit % accept) (concat req req-un opt opt-un)))))
+  (let [keys (impl/extract-keys (s/form spec))]
+    (accept 'clojure.spec/keys spec (mapv #(visit % accept) keys))))
 
 (defmethod visit 'clojure.spec/or [spec accept]
   (let [[_ & {:as inner-spec-map}] (s/form spec)]

--- a/src/spec_tools/visitor.cljc
+++ b/src/spec_tools/visitor.cljc
@@ -167,14 +167,15 @@
 
 (defn convert-specs!
   "Collects all registered subspecs from a spec and
-  transforms their registry values into Spec Records."
+  transforms their registry values into Spec Records.
+  Does not convert clojure.spec regex ops."
   [spec]
   (let [specs (visit spec (spec-collector))
         report (atom #{})]
     (doseq [[k v] specs]
       (if (keyword? v)
         (swap! report into (convert-specs! v))
-        (when-not (st/spec? v)
+        (when-not (or (s/regex? v) (st/spec? v))
           (let [s (st/create-spec {:spec v})]
             (s/def-impl k (s/form s) s)
             (swap! report conj k)))))

--- a/src/spec_tools/visitor.cljc
+++ b/src/spec_tools/visitor.cljc
@@ -155,7 +155,7 @@
 ;; sample visitor
 ;;
 
-(defn collect-specs
+(defn spec-collector
   "a visitor that collects all registered specs. Returns
   a map of spec-name => specs"
   []
@@ -169,7 +169,7 @@
   "Collects all registered subspecs from a spec and
   transforms their registry values into Spec Records."
   [spec]
-  (let [specs (visit spec (collect-specs))
+  (let [specs (visit spec (spec-collector))
         report (atom #{})]
     (doseq [[k v] specs]
       (if (keyword? v)

--- a/src/spec_tools/visitor.cljc
+++ b/src/spec_tools/visitor.cljc
@@ -97,8 +97,8 @@
     (accept dispatch spec [(visit pred accept)])))
 
 (defmethod visit 'clojure.spec/map-of [spec accept]
-  (let [[_ _ v] (s/form spec)]
-    (accept ::map-of spec [(visit v accept)])))
+  (let [[_ k v] (s/form spec)]
+    (accept ::map-of spec (mapv #(visit % accept) [k v]))))
 
 (defmethod visit 'clojure.spec/* [spec accept]
   (let [[_ inner-spec] (s/form spec)]

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -192,11 +192,14 @@
   (testing "without conforming"
     (is (= st/+invalid+ (st/conform spec/int? "12")))
     (is (= {::s/problems [{:path [], :pred 'int?, :val "12", :via [], :in []}]}
-           (st/explain-data spec/int? "12"))))
+           (st/explain-data spec/int? "12")))
+    (is (= "val: \"12\" fails predicate: int?\n"
+           (with-out-str (st/explain spec/int? "12")))))
   (testing "with conforming"
     (is (= 12 (st/conform spec/int? "12" conform/string-conforming)))
-    (is (= nil
-           (st/explain-data spec/int? "12" conform/string-conforming)))))
+    (is (= nil (st/explain-data spec/int? "12" conform/string-conforming)))
+    (is (= "Success!\n"
+           (with-out-str (st/explain spec/int? "12" conform/string-conforming))))))
 
 (s/def ::height integer?)
 (s/def ::weight integer?)

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -202,8 +202,6 @@
 (s/def ::weight integer?)
 (s/def ::person (st/spec (s/keys :req-un [::height ::weight])))
 
-(st/spec (s/keys :req-un [::height ::weight]))
-
 (deftest map-specs-test
   (let [person {:height 200, :weight 80, :age 36}]
 

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -16,6 +16,13 @@
 (s/def ::uuid spec/uuid?)
 (s/def ::birthdate spec/inst?)
 
+(s/def ::a spec/int?)
+(s/def ::b ::a)
+
+(deftest get-spec-test
+  (is (= spec/int? (st/get-spec ::a)))
+  (is (= spec/int? (st/get-spec ::b))))
+
 (deftest coerce-test
   (is (= spec/boolean? (st/coerce-spec ::truth)))
   (is (= spec/boolean? (st/coerce-spec spec/boolean?)))

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -201,6 +201,22 @@
     (is (= "Success!\n"
            (with-out-str (st/explain spec/int? "12" conform/string-conforming))))))
 
+(deftest conform-unform-explain-tests
+  (testing "specs"
+    (let [spec (st/spec (s/or :int spec/int? :bool spec/boolean?))
+          value "1"]
+      (is (= st/+invalid+ (st/conform spec value)))
+      (is (= [:int 1] (st/conform spec value conform/string-conforming)))
+      (is (= 1 (s/unform spec (st/conform spec value conform/string-conforming))))
+      (is (= nil (st/explain-data spec value conform/string-conforming)))))
+  (testing "regexs"
+    (let [spec (st/spec (s/* (s/cat :key spec/keyword? :val spec/int?)))
+          value [:a "1" :b "2"]]
+      (is (= st/+invalid+ (st/conform spec value)))
+      (is (= [{:key :a, :val 1} {:key :b, :val 2}] (st/conform spec value conform/string-conforming)))
+      (is (= [:a 1 :b 2] (s/unform spec (st/conform spec value conform/string-conforming))))
+      (is (= nil (st/explain-data spec value conform/string-conforming))))))
+
 (s/def ::height integer?)
 (s/def ::weight integer?)
 (s/def ::person (st/spec (s/keys :req-un [::height ::weight])))

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -105,7 +105,11 @@
                  (st/deserialize (st/serialize spec))))))
 
       (testing "gen"
-        (is (seq? (s/exercise my-integer?)))))))
+        (is (seq? (s/exercise my-integer?)))
+        (is (every? #{:kikka :kukka} (-> spec/keyword?
+                                         (s/with-gen #(s/gen #{:kikka :kukka}))
+                                         (s/exercise)
+                                         (->> (map first)))))))))
 
 (deftest doc-test
 

--- a/test/cljc/spec_tools/json_schema_test.cljc
+++ b/test/cljc/spec_tools/json_schema_test.cljc
@@ -41,7 +41,8 @@
            {:allOf [{:type "integer"} {:minimum 0 :exclusiveMinimum true}]}))
     ;; merge
     (is (= (jsc/to-json (s/every integer?)) {:type "array" :items {:type "integer"}}))
-    ;; every-ks
+    (is (= (jsc/to-json (s/every-kv string? integer?))
+           {:type "object" :additionalProperties {:type "integer"}}))
     (is (= (jsc/to-json (s/coll-of string?)) {:type "array" :items {:type "string"}}))
     (is (= (jsc/to-json (s/coll-of string? :into '())) {:type "array" :items {:type "string"}}))
     (is (= (jsc/to-json (s/coll-of string? :into [])) {:type "array" :items {:type "string"}}))

--- a/test/cljc/spec_tools/json_schema_test.cljc
+++ b/test/cljc/spec_tools/json_schema_test.cljc
@@ -64,8 +64,8 @@
     ;; keys*
     (is (= (jsc/to-json (s/map-of string? clojure.core/integer?))
            {:type "object" :additionalProperties {:type "integer"}}))
-    ;; nilable
-    )
+    (is (= (jsc/to-json (s/nilable string?))
+           {:oneOf [{:type "string"} {:type "null"}]})))
   (testing "failing clojure.specs"
     (is (not= (jsc/to-json (s/coll-of (s/tuple string? any?) :into {}))
               {:type "object", :additionalProperties {:type "string"}}))))

--- a/test/cljc/spec_tools/json_schema_test.cljc
+++ b/test/cljc/spec_tools/json_schema_test.cljc
@@ -42,7 +42,6 @@
     ;; merge
     (is (= (jsc/to-json (s/every integer?)) {:type "array" :items {:type "integer"}}))
     ;; every-ks
-    ;; coll-of
     (is (= (jsc/to-json (s/coll-of string?)) {:type "array" :items {:type "string"}}))
     (is (= (jsc/to-json (s/coll-of string? :into '())) {:type "array" :items {:type "string"}}))
     (is (= (jsc/to-json (s/coll-of string? :into [])) {:type "array" :items {:type "string"}}))
@@ -52,10 +51,13 @@
     (is (= (jsc/to-json (s/* integer?)) {:type "array" :items {:type "integer"}}))
     (is (= (jsc/to-json (s/+ integer?)) {:type "array" :items {:type "integer"} :minItems 1}))
     (is (= (jsc/to-json (s/? integer?)) {:type "array" :items {:type "integer"} :minItems 0}))
-    ;; alt
     (is (= (jsc/to-json (s/alt :int integer? :string string?))
            {:anyOf [{:type "integer"} {:type "string"}]}))
-    ;; cat
+    (is (= (jsc/to-json (s/cat :int integer? :string string?))
+           {:type "array"
+            :minItems 2
+            :maxItems 2
+            :items {:anyOf [{:type "integer"} {:type "string"}]}}))
     ;; &
     (is (= (jsc/to-json (s/tuple integer? string?))
            {:type "array" :items [{:type "integer"} {:type "string"}] :minItems 2}))

--- a/test/cljc/spec_tools/json_schema_test.cljc
+++ b/test/cljc/spec_tools/json_schema_test.cljc
@@ -58,10 +58,10 @@
             :minItems 2
             :maxItems 2
             :items {:anyOf [{:type "integer"} {:type "string"}]}}))
-    ;; &
+    ;; & is broken (http://dev.clojure.org/jira/browse/CLJ-2152)
     (is (= (jsc/to-json (s/tuple integer? string?))
            {:type "array" :items [{:type "integer"} {:type "string"}] :minItems 2}))
-    ;; keys*
+    ;; keys* is broken (http://dev.clojure.org/jira/browse/CLJ-2152)
     (is (= (jsc/to-json (s/map-of string? clojure.core/integer?))
            {:type "object" :additionalProperties {:type "integer"}}))
     (is (= (jsc/to-json (s/nilable string?))

--- a/test/cljc/spec_tools/json_schema_test.cljc
+++ b/test/cljc/spec_tools/json_schema_test.cljc
@@ -51,7 +51,7 @@
            {:type "object" :additionalProperties {:type "integer"}}))
     (is (= (jsc/to-json (s/* integer?)) {:type "array" :items {:type "integer"}}))
     (is (= (jsc/to-json (s/+ integer?)) {:type "array" :items {:type "integer"} :minItems 1}))
-    ;; ?
+    (is (= (jsc/to-json (s/? integer?)) {:type "array" :items {:type "integer"} :minItems 0}))
     ;; alt
     (is (= (jsc/to-json (s/alt :int integer? :string string?))
            {:anyOf [{:type "integer"} {:type "string"}]}))

--- a/test/cljc/spec_tools/visitor_all_test.cljc
+++ b/test/cljc/spec_tools/visitor_all_test.cljc
@@ -1,0 +1,113 @@
+(ns spec-tools.visitor-all-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [clojure.spec :as s]
+            [spec-tools.visitor :as visitor]
+            [spec-tools.core :as st]))
+
+;;
+;; spec samples
+;;
+
+(s/def ::pred string?)
+
+(s/def ::p1 string?)
+(s/def ::p2 string?)
+(s/def ::p3 string?)
+(s/def ::keys (s/keys :req-un [(or ::p1 (and ::p2 ::p3))]))
+
+(s/def ::p4 string?)
+(s/def ::p5 string?)
+(s/def ::or (s/or :p4 ::p4 :p5 ::p5))
+
+(s/def ::p6 string?)
+(s/def ::and (s/and ::p6 #(> % 18)))
+
+(s/def ::p7 string?)
+(s/def ::keys2 (s/keys :req-un [::p7]))
+(s/def ::p8 string?)
+(s/def ::keys3 (s/keys :req-un [::p8]))
+(s/def ::merge (s/merge ::keys2 ::keys3))
+
+(s/def ::p9 string?)
+(s/def ::every (s/every ::p9))
+
+(s/def ::p10 string?)
+(s/def ::p11 string?)
+(s/def ::every-kv (s/every-kv ::p10 ::p11))
+
+(s/def ::p12 string?)
+(s/def ::coll-of (s/coll-of ::p12))
+
+(s/def ::p13 string?)
+(s/def ::p14 string?)
+(s/def ::map-of (s/map-of ::p13 ::p14))
+
+(s/def ::p15 string?)
+(s/def ::* (s/* ::p15))
+
+(s/def ::p16 string?)
+(s/def ::+ (s/* ::p16))
+
+(s/def ::p17 string?)
+(s/def ::? (s/* ::p17))
+
+(s/def ::p18 string?)
+(s/def ::p19 int?)
+(s/def ::alt (s/alt :p18 ::p18 ::p19 ::p19))
+
+(s/def ::p20 string?)
+(s/def ::p21 string?)
+(s/def ::cat (s/cat :p20 ::p20, :p21 ::p21))
+
+;; BROKEN FORM
+#_(s/def ::p22 string?)
+#_(s/def ::& (s/& ::p22))
+
+(s/def ::p23 string?)
+(s/def ::p24 string?)
+(s/def ::tuple (s/tuple ::p23 ::p24))
+
+;; BROKEN FORM
+#_(s/def ::p25 string?)
+#_(s/def ::p26 string?)
+#_(s/def ::p27 string?)
+#_(s/def ::keys* (s/keys* :req-un [(or ::p25 (and ::p26 ::p27))]))
+
+(s/def ::p28 string?)
+(s/def ::nilable (s/nilable ::p28))
+
+;;
+;; everything together
+;;
+
+(s/def ::all
+  (s/tuple
+    ::pred
+    ::keys
+    ::or
+    ::and
+    ::merge
+    ::every
+    ::every-kv
+    ::coll-of
+    ::map-of
+    ::*
+    ::+
+    ::?
+    ::alt
+    ::cat
+    #_::&
+    ::tuple
+    #_::keys*
+    ::nilable))
+
+;;
+;; tests
+;;
+
+(deftest visit-all-test
+  (testing "visitor visits all specs"
+    (is (= (set (keys (st/registry #"^spec-tools.visitor-all-test.*")))
+           (->> (visitor/visit ::all (visitor/collect-specs))
+                (keys)
+                (set))))))

--- a/test/cljc/spec_tools/visitor_all_test.cljc
+++ b/test/cljc/spec_tools/visitor_all_test.cljc
@@ -1,8 +1,7 @@
 (ns spec-tools.visitor-all-test
   (:require [clojure.test :refer [deftest testing is]]
             [clojure.spec :as s]
-            [spec-tools.visitor :as visitor]
-            [spec-tools.core :as st]))
+            [spec-tools.visitor :as visitor]))
 
 ;;
 ;; spec samples
@@ -13,68 +12,82 @@
 (s/def ::p1 string?)
 (s/def ::p2 string?)
 (s/def ::p3 string?)
-(s/def ::keys (s/keys :req-un [(or ::p1 (and ::p2 ::p3))]))
-
 (s/def ::p4 string?)
 (s/def ::p5 string?)
-(s/def ::or (s/or :p4 ::p4 :p5 ::p5))
-
 (s/def ::p6 string?)
-(s/def ::and (s/and ::p6 #(> % 18)))
+(s/def ::keys (s/keys
+                :req [(or ::p1 (and ::p2 ::p3))]
+                :opt [::p4]
+                :req-un [::p5]
+                :opt-un [::p6]))
 
 (s/def ::p7 string?)
-(s/def ::keys2 (s/keys :req-un [::p7]))
 (s/def ::p8 string?)
-(s/def ::keys3 (s/keys :req-un [::p8]))
-(s/def ::merge (s/merge ::keys2 ::keys3))
+(s/def ::or (s/or :a ::p7 :b ::p8))
 
 (s/def ::p9 string?)
-(s/def ::every (s/every ::p9))
+(s/def ::and (s/and ::p9 #(> % 18)))
 
 (s/def ::p10 string?)
+(s/def ::keys2 (s/keys :req-un [::p10]))
 (s/def ::p11 string?)
-(s/def ::every-kv (s/every-kv ::p10 ::p11))
+(s/def ::keys3 (s/keys :req-un [::p11]))
+(s/def ::merge (s/merge ::keys2 ::keys3))
 
 (s/def ::p12 string?)
-(s/def ::coll-of (s/coll-of ::p12))
+(s/def ::every (s/every ::p12))
 
 (s/def ::p13 string?)
 (s/def ::p14 string?)
-(s/def ::map-of (s/map-of ::p13 ::p14))
+(s/def ::every-kv (s/every-kv ::p13 ::p14))
 
 (s/def ::p15 string?)
-(s/def ::* (s/* ::p15))
+(s/def ::coll-of (s/coll-of ::p15))
 
 (s/def ::p16 string?)
-(s/def ::+ (s/* ::p16))
-
 (s/def ::p17 string?)
-(s/def ::? (s/* ::p17))
+(s/def ::map-of (s/map-of ::p16 ::p17))
 
 (s/def ::p18 string?)
-(s/def ::p19 int?)
-(s/def ::alt (s/alt :p18 ::p18 ::p19 ::p19))
+(s/def ::* (s/* ::p18))
+
+(s/def ::p19 string?)
+(s/def ::+ (s/* ::p19))
 
 (s/def ::p20 string?)
-(s/def ::p21 string?)
-(s/def ::cat (s/cat :p20 ::p20, :p21 ::p21))
+(s/def ::? (s/* ::p20))
 
-;; BROKEN FORM
-#_(s/def ::p22 string?)
-#_(s/def ::& (s/& ::p22))
+(s/def ::p21 string?)
+(s/def ::p22 int?)
+(s/def ::alt (s/alt :a ::p21 :b ::p22))
 
 (s/def ::p23 string?)
 (s/def ::p24 string?)
-(s/def ::tuple (s/tuple ::p23 ::p24))
+(s/def ::cat (s/cat :a ::p23, :b ::p24))
 
-;; BROKEN FORM
-#_(s/def ::p25 string?)
-#_(s/def ::p26 string?)
-#_(s/def ::p27 string?)
-#_(s/def ::keys* (s/keys* :req-un [(or ::p25 (and ::p26 ::p27))]))
+;; BROKEN FORM (http://dev.clojure.org/jira/browse/CLJ-2152)
+(s/def ::p25 string?)
+(s/def ::& (s/& ::p25))
 
+(s/def ::p26 string?)
+(s/def ::p27 string?)
+(s/def ::tuple (s/tuple ::p26 ::p27))
+
+;; BROKEN FORM (http://dev.clojure.org/jira/browse/CLJ-2152)
 (s/def ::p28 string?)
-(s/def ::nilable (s/nilable ::p28))
+(s/def ::p29 string?)
+(s/def ::p30 string?)
+(s/def ::p31 string?)
+(s/def ::p32 string?)
+(s/def ::p33 string?)
+(s/def ::keys* (s/keys*
+                 :req [(or ::p28 (and ::p29 ::p30))]
+                 :opt [::p31]
+                 :req-un [::p32]
+                 :opt-un [::p33]))
+
+(s/def ::p34 string?)
+(s/def ::nilable (s/nilable ::p34))
 
 ;;
 ;; everything together
@@ -96,18 +109,37 @@
     ::?
     ::alt
     ::cat
-    #_::&
+    ::&
     ::tuple
-    #_::keys*
+    ::keys*
     ::nilable))
 
 ;;
 ;; tests
 ;;
 
+(deftest CLJ-2152-test
+  (testing "this should fail when the issues is fixed"
+    (is (not (= `(s/& int?) (s/form (s/& int?)))))))
+
+(deftest nested-regexp-test
+  (is (= #{::p1 ::p2 ::p3}
+         (->> (visitor/visit
+                (s/* (s/cat :prop ::p1 :val (s/alt :s ::p2 :b ::p3)))
+                (visitor/collect-specs))
+              (keys)
+              (set)))))
+
 (deftest visit-all-test
-  (testing "visitor visits all specs"
-    (is (= (set (keys (st/registry #"^spec-tools.visitor-all-test.*")))
+  (testing "visitor visits all specs but not s/& & s/keys* inner specs"
+    (is (= #{::p1 ::p2 ::p3 ::p4 ::p5 ::p6 ::p7 ::p8 ::p9 ::p10
+             ::p11 ::p12 ::p13 ::p14 ::p15 ::p16 ::p17 ::p18 ::p19 ::p20
+             ::p21 ::p22 ::p23 ::p24 #_::p25 ::p26 ::p27 #_::p28 #_::p29 #_::p30
+             #_::p31 #_::p32 #_:p33 ::p34
+             ::pred ::keys ::keys2 ::keys3
+             ::or ::and ::merge ::every ::every-kv ::coll-of ::map-of
+             ::* ::+ ::? ::alt ::cat ::& ::tuple ::keys* ::nilable ::all}
+
            (->> (visitor/visit ::all (visitor/collect-specs))
                 (keys)
                 (set))))))

--- a/test/cljc/spec_tools/visitor_all_test.cljc
+++ b/test/cljc/spec_tools/visitor_all_test.cljc
@@ -126,7 +126,7 @@
   (is (= #{::p1 ::p2 ::p3}
          (->> (visitor/visit
                 (s/* (s/cat :prop ::p1 :val (s/alt :s ::p2 :b ::p3)))
-                (visitor/collect-specs))
+                (visitor/spec-collector))
               (keys)
               (set)))))
 
@@ -140,6 +140,6 @@
              ::or ::and ::merge ::every ::every-kv ::coll-of ::map-of
              ::* ::+ ::? ::alt ::cat ::& ::tuple ::keys* ::nilable ::all}
 
-           (->> (visitor/visit ::all (visitor/collect-specs))
+           (->> (visitor/visit ::all (visitor/spec-collector))
                 (keys)
                 (set))))))

--- a/test/cljc/spec_tools/visitor_test.cljc
+++ b/test/cljc/spec_tools/visitor_test.cljc
@@ -55,7 +55,7 @@
                    :spec-tools.visitor-test$person$address/street
                    :spec-tools.visitor-test$person$address/zip
                    :spec-tools.visitor-test$person/address}
-        specs (visitor/visit person-spec (visitor/collect-specs))]
+        specs (visitor/visit person-spec (visitor/spec-collector))]
     (testing "all specs are found"
       (is (= expected (-> specs keys set))))
     (testing "all spec forms are correct"

--- a/test/cljc/spec_tools/visitor_test.cljc
+++ b/test/cljc/spec_tools/visitor_test.cljc
@@ -62,11 +62,10 @@
       (is (= (->> expected (map s/get-spec) set)
              (-> specs vals set))))
 
-    #?(:clj
-       (testing "convert-specs! transforms all specs into Spec records"
-         (visitor/convert-specs! person-spec)
-         (is (true?
-               (->> expected
-                    (map s/get-spec)
-                    (remove keyword?)
-                    (every? st/spec?))))))))
+    (testing "convert-specs! transforms all specs into Spec records"
+      (visitor/convert-specs! person-spec)
+      (is (true?
+            (->> expected
+                 (map s/get-spec)
+                 (remove keyword?)
+                 (every? st/spec?)))))))


### PR DESCRIPTION
* make `explain*` and `conform*` work with regex ops
* visitor now walk over all specs. `s/&` & `s/keys*` are broken, reported http://dev.clojure.org/jira/browse/CLJ-2152
  * tests to verify
* JSON Schema for all specs expect `s/merge`
* `convert-specs!` works with cljs too.