### PR TITLE
from type to spec -based conforming

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Can be added to a Spec via the key `:reason`
 
 Spec-tools loans from the awesome [Schema](https://github.com/plumatic/schema) by separating specs (what) from conformers (how). Spec Records contain a dynamical conformer, which can be instructed at runtime to use a suitable conforming function for that spec. Specs can conform differently, e.g. when reading data from JSON or Transit.
 
-Spec Record conform is by default a no-op. Binding a dynamic var `spec-tools.core/*conformering*` with a function of `spec => spec-conformer` will cause the Spec to be conformed with the selected spec-conformer. `spec-tools.core` has helper functions for setting the binding: `explain`, `explain-data`, `conform` and `conform!`.
+Spec Record conform is by default a no-op. Binding a dynamic var `spec-tools.core/*conforming*` with a function of `spec => spec-conformer` will cause the Spec to be conformed with the selected spec-conformer. `spec-tools.core` has helper functions for setting the binding: `explain`, `explain-data`, `conform` and `conform!`.
 
 Spec-conformers are arity2 functions taking the Spec Records and the value and should return either conformed value of `:clojure.spec/invalid`.
 

--- a/README.md
+++ b/README.md
@@ -147,8 +147,6 @@ Spec-conformers are arity2 functions taking the Spec Records and the value and s
 
 A common way to do dynamic conforming is to select conformer based on the specs `:type`. By default, the following spec types are supported (and mostly, auto-resolved): `:long`, `:double`, `:boolean`, `:string`, `:keyword`, `:symbol`, `:uuid`, `:uri`, `:bigdec`, `:date`, `:ratio`, `:map`, `:set` and `:vector`.
 
-`spec-tools.conform` has spec-conformer functions for different types and required type mappings to build type-based conforming out of those.
-
 The following type-based conforming are found in `spec-tools.core`:
 
 | Name                            | Description                                                                                                              |
@@ -167,8 +165,8 @@ Type-based conforming mappings are defined as data, so they are easy to combine 
 (def strict-json-conforming
   (st/type-conforming
     (merge
-      conform/json-type-conforming-opts
-      conform/strip-extra-keys-type-conforming-opts)))
+      conform/json-type-conforming
+      conform/strip-extra-keys-type-conforming)))
 ```
 
 #### Conforming examples
@@ -259,7 +257,7 @@ To strip out keys from a keyset:
 (def my-string-conforming
   (st/type-conforming
     (assoc
-      conform/string-type-conforming-opts
+      conform/string-type-conforming
       :keyword
       (fn [_ value]
         (-> value

--- a/src/spec_tools/conform.cljc
+++ b/src/spec_tools/conform.cljc
@@ -84,10 +84,10 @@
     x))
 
 ;;
-;; conforming
+;; type conforming
 ;;
 
-(def json-type-conforming-opts
+(def json-type-conforming
   (merge
     {:keyword string->keyword
      :uuid string->uuid
@@ -98,17 +98,17 @@
         :bigdec nil
         :ratio nil})))
 
-(def string-type-conforming-opts
+(def string-type-conforming
   (merge
-    json-type-conforming-opts
+    json-type-conforming
     {:long string->long
      :double string->double
      :boolean string->boolean
      :nil string->nil
      :string nil}))
 
-(def strip-extra-keys-type-conforming-opts
+(def strip-extra-keys-type-conforming
   {:map strip-extra-keys})
 
-(def fail-on-extra-keys-type-conforming-opts
+(def fail-on-extra-keys-type-conforming
   {:map fail-on-extra-keys})

--- a/src/spec_tools/conform.cljc
+++ b/src/spec_tools/conform.cljc
@@ -87,7 +87,7 @@
 ;; conforming
 ;;
 
-(def json-conforming
+(def json-type-conforming-opts
   (merge
     {:keyword string->keyword
      :uuid string->uuid
@@ -98,17 +98,17 @@
         :bigdec nil
         :ratio nil})))
 
-(def string-conforming
+(def string-type-conforming-opts
   (merge
-    json-conforming
+    json-type-conforming-opts
     {:long string->long
      :double string->double
      :boolean string->boolean
      :nil string->nil
      :string nil}))
 
-(def strip-extra-keys-conforming
+(def strip-extra-keys-type-conforming-opts
   {:map strip-extra-keys})
 
-(def fail-on-extra-keys-conforming
+(def fail-on-extra-keys-type-conforming-opts
   {:map fail-on-extra-keys})

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -3,6 +3,7 @@
   (:require [spec-tools.impl :as impl]
             [spec-tools.type :as type]
             [spec-tools.form :as form]
+            [spec-tools.conform :as conform]
             [clojure.spec :as s]
     #?@(:clj  [
             [clojure.spec.gen :as gen]
@@ -73,6 +74,23 @@
 
 (def ^:dynamic ^:private *conforming* nil)
 
+(defn type-conforming [opts]
+  (fn [spec]
+    (let [type (:type spec)]
+      (get opts type))))
+
+(def json-conforming
+  (type-conforming conform/json-type-conforming-opts))
+
+(def string-conforming
+  (type-conforming conform/string-type-conforming-opts))
+
+(def strip-extra-keys-conforming
+  (type-conforming conform/strip-extra-keys-type-conforming-opts))
+
+(def fail-on-extra-keys-conforming
+  (type-conforming conform/fail-on-extra-keys-type-conforming-opts))
+
 (defn explain
   ([spec value]
    (explain spec value nil))
@@ -141,7 +159,7 @@
     (if (and (fn? spec) (spec x))
       x
       ;; there is a dynamic conformer
-      (if-let [conform (get *conforming* type)]
+      (if-let [conform (if *conforming* (*conforming* this))]
         (conform this x)
         ;; spec or regex
         (if (or (s/spec? spec) (s/regex? spec))

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -80,16 +80,16 @@
       (get opts type))))
 
 (def json-conforming
-  (type-conforming conform/json-type-conforming-opts))
+  (type-conforming conform/json-type-conforming))
 
 (def string-conforming
-  (type-conforming conform/string-type-conforming-opts))
+  (type-conforming conform/string-type-conforming))
 
 (def strip-extra-keys-conforming
-  (type-conforming conform/strip-extra-keys-type-conforming-opts))
+  (type-conforming conform/strip-extra-keys-type-conforming))
 
 (def fail-on-extra-keys-conforming
-  (type-conforming conform/fail-on-extra-keys-type-conforming-opts))
+  (type-conforming conform/fail-on-extra-keys-type-conforming))
 
 (defn explain
   ([spec value]

--- a/test/clj/spec_tools/perf_test.clj
+++ b/test/clj/spec_tools/perf_test.clj
@@ -4,8 +4,7 @@
             [spec-tools.core :as st]
             [spec-tools.spec :as spec]
             [criterium.core :as cc]
-            [clojure.spec :as s]
-            [spec-tools.conform :as conform]))
+            [clojure.spec :as s]))
 
 ;;
 ;; start repl with `lein perf repl`
@@ -122,7 +121,7 @@
     ; 1440ns (alpha12)
     ; 1160ns (alpha14)
     (title "spec: conform keyword enum")
-    (let [call #(st/conform sizes-spec ["L" "M"] conform/string-conforming)]
+    (let [call #(st/conform sizes-spec ["L" "M"] st/string-conforming)]
       (assert (= (call) #{:L :M}))
       (cc/quick-bench
         (call)))
@@ -131,7 +130,7 @@
     ; 990ns (alpha12)
     ; 990ns (alpha14)
     (title "spec: conform keyword enum - no-op")
-    (let [call #(st/conform sizes-spec #{:L :M} conform/string-conforming)]
+    (let [call #(st/conform sizes-spec #{:L :M} st/string-conforming)]
       (assert (= (call) #{:L :M}))
       (cc/quick-bench
         (call)))
@@ -218,7 +217,7 @@
   ; 4.5µs (alpha12)
   ; 3.9µs (alpha14)
   (title "spec: conform")
-  (let [call #(st/conform ::order sample-order conform/string-conforming)]
+  (let [call #(st/conform ::order sample-order st/string-conforming)]
     (assert (= (call) sample-order-valid))
     (cc/quick-bench
       (call)))
@@ -226,7 +225,7 @@
   ; 2.8µs (alpha12)
   ; 2.7µs (alpha14)
   (title "spec: conform - no-op")
-  (let [call #(st/conform ::order sample-order-valid conform/string-conforming)]
+  (let [call #(st/conform ::order sample-order-valid st/string-conforming)]
     (assert (= (call) sample-order-valid))
     (cc/quick-bench
       (call)))

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -154,7 +154,7 @@
       (is (= st/+invalid+ (st/conform ::birthdate "2014-02-18T18:25:37Z")))))
 
   (testing "string-conforming"
-    (let [conform #(st/conform %1 %2 conform/string-conforming)]
+    (let [conform #(st/conform %1 %2 st/string-conforming)]
       (testing "everything gets conformed"
         (is (= 12 (conform ::age "12")))
         (is (= 1234567 (conform ::over-a-million "1234567")))
@@ -169,7 +169,7 @@
                (conform ::birthdate "2014-02-18T18:25:37Z"))))))
 
   (testing "json-conforming"
-    (let [conform #(st/conform %1 %2 conform/json-conforming)]
+    (let [conform #(st/conform %1 %2 st/json-conforming)]
       (testing "some are not conformed"
         (is (= st/+invalid+ (conform ::age "12")))
         (is (= st/+invalid+ (conform ::over-a-million "1234567")))
@@ -186,7 +186,7 @@
 
 (deftest conform!-test
   (testing "suceess"
-    (is (= 12 (st/conform! ::age "12" conform/string-conforming))))
+    (is (= 12 (st/conform! ::age "12" st/string-conforming))))
   (testing "failing"
     (is (thrown? #?(:clj Exception, :cljs js/Error) (st/conform! ::age "12")))
     (try
@@ -207,26 +207,26 @@
     (is (= "val: \"12\" fails predicate: int?\n"
            (with-out-str (st/explain spec/int? "12")))))
   (testing "with conforming"
-    (is (= 12 (st/conform spec/int? "12" conform/string-conforming)))
-    (is (= nil (st/explain-data spec/int? "12" conform/string-conforming)))
+    (is (= 12 (st/conform spec/int? "12" st/string-conforming)))
+    (is (= nil (st/explain-data spec/int? "12" st/string-conforming)))
     (is (= "Success!\n"
-           (with-out-str (st/explain spec/int? "12" conform/string-conforming))))))
+           (with-out-str (st/explain spec/int? "12" st/string-conforming))))))
 
 (deftest conform-unform-explain-tests
   (testing "specs"
     (let [spec (st/spec (s/or :int spec/int? :bool spec/boolean?))
           value "1"]
       (is (= st/+invalid+ (st/conform spec value)))
-      (is (= [:int 1] (st/conform spec value conform/string-conforming)))
-      (is (= 1 (s/unform spec (st/conform spec value conform/string-conforming))))
-      (is (= nil (st/explain-data spec value conform/string-conforming)))))
+      (is (= [:int 1] (st/conform spec value st/string-conforming)))
+      (is (= 1 (s/unform spec (st/conform spec value st/string-conforming))))
+      (is (= nil (st/explain-data spec value st/string-conforming)))))
   (testing "regexs"
     (let [spec (st/spec (s/* (s/cat :key spec/keyword? :val spec/int?)))
           value [:a "1" :b "2"]]
       (is (= st/+invalid+ (st/conform spec value)))
-      (is (= [{:key :a, :val 1} {:key :b, :val 2}] (st/conform spec value conform/string-conforming)))
-      (is (= [:a 1 :b 2] (s/unform spec (st/conform spec value conform/string-conforming))))
-      (is (= nil (st/explain-data spec value conform/string-conforming))))))
+      (is (= [{:key :a, :val 1} {:key :b, :val 2}] (st/conform spec value st/string-conforming)))
+      (is (= [:a 1 :b 2] (s/unform spec (st/conform spec value st/string-conforming))))
+      (is (= nil (st/explain-data spec value st/string-conforming))))))
 
 (s/def ::height integer?)
 (s/def ::weight integer?)
@@ -242,11 +242,11 @@
 
     (testing "stripping extra keys"
       (is (= {:height 200, :weight 80}
-             (st/conform ::person person conform/strip-extra-keys-conforming))))
+             (st/conform ::person person st/strip-extra-keys-conforming))))
 
     (testing "failing on extra keys"
       (is (= st/+invalid+
-             (st/conform ::person person conform/fail-on-extra-keys-conforming))))))
+             (st/conform ::person person st/fail-on-extra-keys-conforming))))))
 
 (s/def ::human (st/spec (s/keys :req-un [::height ::weight]) {:type ::human}))
 
@@ -266,10 +266,11 @@
 
     (testing "bmi-conforming"
       (is (= {:height 200, :weight 80, :bmi 20.0}
-             (st/conform ::human person {::human bmi-conformer}))))))
+             (st/conform ::human person (st/type-conforming
+                                          {::human bmi-conformer})))))))
 
 (deftest unform-test
-  (let [unform-conform #(s/unform %1 (st/conform %1 %2 conform/string-conforming))]
+  (let [unform-conform #(s/unform %1 (st/conform %1 %2 st/string-conforming))]
     (testing "conformed values can be unformed"
       (is (= 12 (unform-conform ::age "12")))
       (is (= 1234567 (unform-conform ::age "1234567")))
@@ -284,16 +285,17 @@
              (unform-conform ::birthdate "2014-02-18T18:25:37.456Z"))))))
 
 (deftest extending-test
-  (let [my-conforming (-> conform/string-conforming
-                          (assoc
-                            :keyword
-                            (fn [_ value]
-                              (-> value
-                                  str/upper-case
-                                  str/reverse
-                                  keyword))))]
+  (let [my-conforming (st/type-conforming
+                        (assoc
+                          conform/string-type-conforming-opts
+                          :keyword
+                          (fn [_ value]
+                            (-> value
+                                str/upper-case
+                                str/reverse
+                                keyword))))]
     (testing "string-conforming"
-      (is (= :kikka (st/conform spec/keyword? "kikka" conform/string-conforming))))
+      (is (= :kikka (st/conform spec/keyword? "kikka" st/string-conforming))))
     (testing "my-conforming"
       (is (= :AKKIK (st/conform spec/keyword? "kikka" my-conforming))))))
 
@@ -368,7 +370,7 @@
 
           (testing "map-conforming works recursively"
             (is (= value
-                   (st/conform person-spec bloated {:map conform/strip-extra-keys}))))))))
+                   (st/conform person-spec bloated st/strip-extra-keys-conforming))))))))
 
   (testing "top-level vector"
     (is (true?
@@ -420,7 +422,7 @@
            (st/conform
              (st/data-spec ::kikka {keyword? keyword?})
              {"thanks" "alex"}
-             conform/string-conforming)))))
+             st/string-conforming)))))
 
 (deftest extract-extra-info-test
   (testing "all keys types are extracted"

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -287,7 +287,7 @@
 (deftest extending-test
   (let [my-conforming (st/type-conforming
                         (assoc
-                          conform/string-type-conforming-opts
+                          conform/string-type-conforming
                           :keyword
                           (fn [_ value]
                             (-> value


### PR DESCRIPTION
* fixes https://github.com/metosin/spec-tools/issues/44
* also, push top-level conforming into `spec-tools.core` for easier access (the 99% case).