### PR TITLE
Remove hard dependency on ClojureScript

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/spec-tools "0.1.0"
+(defproject metosin/spec-tools "0.1.1"
   :description "Clojure(Script) tools for clojure.spec"
   :url "https://github.com/metosin/spec-tools"
   :license {:name "Eclipse Public License"

--- a/src/spec_tools/impl.cljc
+++ b/src/spec_tools/impl.cljc
@@ -1,9 +1,9 @@
 (ns spec-tools.impl
   (:refer-clojure :exclude [resolve])
-  (:require [cljs.analyzer.api :refer [resolve]]
-            [spec-tools.form :as form]
-            [clojure.spec :as s]
-            [clojure.walk :as walk])
+  (:require #?(:cljs [cljs.analyzer.api :refer [resolve]])
+    [spec-tools.form :as form]
+    [clojure.spec :as s]
+    [clojure.walk :as walk])
   (:import
     #?@(:clj
         [(clojure.lang Var)])))
@@ -43,8 +43,10 @@
       (conj (walk/postwalk-replace {s '%} form) '[%] (if cljs? 'cljs.core/fn 'clojure.core/fn)))
     expr))
 
-(defn cljs-resolve [env symbol]
-  (clojure.core/or (->> symbol (resolve env) cljs-sym) symbol))
+#?(:cljs
+   (defn cljs-resolve [env symbol]
+     (clojure.core/or (->> symbol (resolve env) cljs-sym) symbol))
+   :clj (declare cljs-resolve))
 
 (defn polish [x]
   (cond


### PR DESCRIPTION
spec-tools v0.1.0 places a hard dependency on ClojureScript. Trying to load `spec-tools.core` in an all Clojure project results in this error: 

```
java.io.FileNotFoundException: Could not locate cljs/analyzer/api__init.class or cljs/analyzer/api.clj on classpath.
```
The ClojureScript analyzer is required in [impl.cljc](https://github.com/metosin/spec-tools/blob/ec5a62d0c25211c6aac7e62fe2ccde902ad38a04/src/spec_tools/impl.cljc#L3). Does ClojureScript need to be a hard dependency? If not, here is a PR removing the `require` for the CLJS analyzer in Clojure code.