### PR TITLE
0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## UNRELEASED
+## 0.2.2-SNAPSHOT
 
-* Spec Record `describe*` uses the map syntax, e.g. `(st/spec clojure.core/string? {}` => `(st/spec {:spec clojure.core/string?}`
+* Spec Record `describe*` uses the map syntax, e.g. `(st/spec clojure.core/string? {}` => `(st/spec {:spec clojure.core/string?})`
 
 ## 0.2.1 (9.7.2917)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+* Spec Record `describe*` uses the map syntax, e.g. `(st/spec clojure.core/string? {}` => `(st/spec {:spec clojure.core/string?}`
+
 ## 0.2.1 (9.7.2917)
 
 * fixed `explain*` for Spec Records

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Spec Record `describe*` uses the map syntax, e.g. `(st/spec clojure.core/string? {}` => `(st/spec {:spec clojure.core/string?})`
 
+* Spec Records inherit `::s/name` from underlaying specs, fixes [#56](https://github.com/metosin/spec-tools/issues/56)
+
 ## 0.2.1 (9.7.2917)
 
 * fixed `explain*` for Spec Records

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/spec-tools "0.2.1"
+(defproject metosin/spec-tools "0.2.2-SNAPSHOT"
   :description "Clojure(Script) tools for clojure.spec"
   :url "https://github.com/metosin/spec-tools"
   :license {:name "Eclipse Public License"

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -268,9 +268,11 @@
         info (extract-extra-info form)
         type (if-not (contains? m :type)
                (type/resolve-type form)
-               type)]
-    (map->Spec
-      (merge m info {:spec spec :form form, :type type}))))
+               type)
+        name (-> spec meta ::s/name)
+        record (map->Spec
+                 (merge m info {:spec spec :form form, :type type}))]
+    (cond-> record name (with-meta {::s/name name}))))
 
 #?(:clj
    (defmacro spec

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -203,8 +203,8 @@
   (with-gen* [this gfn]
     (assoc this :gen gfn))
   (describe* [this]
-    (let [info (extra-spec-map this)]
-      `(spec-tools.core/spec ~form ~info)))
+    (let [data (merge {:spec form} (extra-spec-map this))]
+      `(spec-tools.core/spec ~data)))
   IFn
   #?(:clj  (invoke [this x] (if (ifn? spec) (spec x) (fail-on-invoke this)))
      :cljs (-invoke [this x] (if (ifn? spec) (spec x) (fail-on-invoke this)))))

--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -181,15 +181,6 @@
 (defmethod accept-spec ::visitor/set [dispatch spec children]
   {:enum children})
 
-(defn- is-map-of?
-  "Predicate to check if spec looks like an expansion of clojure.spec.alpha/map-of."
-  [spec]
-  (let [[_ inner-spec & {:as kwargs}] (visitor/extract-form spec)
-        pred (when (seq? inner-spec) (first inner-spec))]
-    ;; (s/map-of key-spec value-spec) expands to
-    ;; (s/every (s/tuple key-spec value-spec) :into {} ...)
-    (and (= pred #?(:clj 'clojure.spec.alpha/tuple :cljs 'cljs.spec.alpha/tuple)) (= (get kwargs :into)) {})))
-
 (defmethod accept-spec 'clojure.spec.alpha/keys [dispatch spec children]
   (let [[_ & {:keys [req req-un opt opt-un]}] (visitor/extract-form spec)
         names-un    (map name (concat req-un opt-un))
@@ -214,13 +205,10 @@
 (defmethod accept-spec 'clojure.spec.alpha/every [dispatch spec children]
   (let [form (visitor/extract-form spec)
         type (type/resolve-type form)]
-    ;; Special case handling of s/map-of, which expands to s/every
-    (if (is-map-of? spec)
-      {:type "object" :additionalProperties (get-in (unwrap children) [:items 1])}
-      (case type
-        :map {:type "object", :additionalProperties (unwrap children)}
-        :set {:type "array", :uniqueItems true, :items (unwrap children)}
-        :vector {:type "array", :items (unwrap children)}))))
+    (case type
+      :map {:type "object", :additionalProperties (unwrap children)}
+      :set {:type "array", :uniqueItems true, :items (unwrap children)}
+      :vector {:type "array", :items (unwrap children)})))
 
 (defmethod accept-spec 'clojure.spec.alpha/every-kv [dispatch spec children]
   {:type "object", :additionalProperties (second children)})

--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -268,15 +268,15 @@
     {:minimum minimum :maximum maximum}))
 
 (defmethod accept-spec ::visitor/spec [dispatch spec children]
-  (let [spec (visitor/extract-spec spec)
+  (let [[_ data] (visitor/extract-form spec)
         json-schema-meta (reduce-kv
                            (fn [acc k v]
                              (if (= "json-schema" (namespace k))
                                (assoc acc (keyword (name k)) v)
                                acc))
                            {}
-                           (into {} spec))
-        extra-info (-> spec
+                           (into {} data))
+        extra-info (-> data
                        (select-keys [:name :description])
                        (set/rename-keys {:name :title}))]
     (merge (unwrap children) extra-info json-schema-meta)))

--- a/src/spec_tools/visitor.cljc
+++ b/src/spec_tools/visitor.cljc
@@ -19,10 +19,6 @@
     "cljs.spec.alpha" (symbol "clojure.spec.alpha" (name kw))
     kw))
 
-(defn extract-spec [spec]
-  (let [[_ form opts] (if (seq? spec) spec (s/form spec))]
-    (assoc opts :form form)))
-
 (defn extract-form [spec]
   (if (seq? spec) spec (s/form spec)))
 
@@ -141,7 +137,7 @@
     (accept 'clojure.spec.alpha/nilable spec [(visit inner-spec accept)])))
 
 (defmethod visit 'spec-tools.core/spec [spec accept]
-  (let [[_ inner-spec] (extract-form spec)]
+  (let [[_ {inner-spec :spec}] (extract-form spec)]
     (accept ::spec spec [(visit inner-spec accept)])))
 
 (defmethod visit ::default [spec accept]

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -55,6 +55,9 @@
                (st/create-spec {:spec integer?, :form `integer?})
                (st/create-spec {:spec integer?, :form `integer?, :type :long}))))
 
+      (testing "::s/name is retained"
+        (is (= ::age (::s/name (meta (st/create-spec {:spec ::age}))))))
+
       (testing "anonymous functions"
 
         (testing ":form default to ::s/unknown"

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -84,35 +84,35 @@
 
         (st/spec integer?)
         `(spec-tools.core/spec
-           integer?
-           {:type :long})
+           {:spec integer?
+            :type :long})
 
         (st/spec #{pos? neg?})
         `(spec-tools.core/spec
-           #{neg? pos?}
-           {:type nil})
+           {:spec #{neg? pos?}
+            :type nil})
 
         (st/spec ::string)
         `(spec-tools.core/spec
-           string?
-           {:type :string})
+           {:spec string?
+            :type :string})
 
         (st/spec ::lat)
         `(spec-tools.core/spec
-           (spec-tools.core/spec
-             double?
-             {:type :double})
-           {:type nil})
+           {:spec (spec-tools.core/spec
+                    {:spec double?
+                     :type :double})
+            :type nil})
 
         (st/spec (fn [x] (> x 10)))
         `(spec-tools.core/spec
-           (clojure.core/fn [~'x] (> ~'x 10))
-           {:type nil})
+           {:spec (clojure.core/fn [~'x] (> ~'x 10))
+            :type nil})
 
         (st/spec #(> % 10))
         `(spec-tools.core/spec
-           (clojure.core/fn [~'%] (> ~'% 10))
-           {:type nil})))
+           {:spec (clojure.core/fn [~'%] (> ~'% 10))
+            :type nil})))
 
     (testing "wrapped predicate work as a predicate"
       (is (true? (my-integer? 1)))
@@ -137,18 +137,18 @@
 
       (testing "fully qualifed predicate symbol is returned with s/form"
         (is (= ['spec-tools.core/spec
-                #?(:clj  'clojure.core/integer?
-                   :cljs 'cljs.core/integer?)
-                {:type :long}] (s/form my-integer?)))
-        (is (= ['spec 'integer? {:type :long}] (s/describe my-integer?))))
+                {:spec #?(:clj  'clojure.core/integer?
+                          :cljs 'cljs.core/integer?)
+                 :type :long}] (s/form my-integer?)))
+        (is (= ['spec {:spec 'integer? :type :long}] (s/describe my-integer?))))
 
       (testing "type resolution"
         (is (= (st/spec integer?)
                (st/spec integer? {:type :long}))))
 
       (testing "serialization"
-        (let [spec (st/spec integer? {:description "cool", :type ::integer})]
-          (is (= `(st/spec integer? {:description "cool", :type ::integer})
+        (let [spec (st/spec {:spec integer? :description "cool", :type ::integer})]
+          (is (= `(st/spec {:spec integer? :description "cool", :type ::integer})
                  (s/form spec)
                  (st/deserialize (st/serialize spec))))))
 
@@ -172,7 +172,7 @@
       (is (= "kikka" (:description spec)))
       (is (true? (s/valid? spec 1)))
       (is (false? (s/valid? spec "1")))
-      (is (= `(st/spec integer? {:description "kikka", :type nil})
+      (is (= `(st/spec {:spec integer? :description "kikka", :type nil})
              (st/deserialize (st/serialize spec))
              (s/form spec))))))
 

--- a/test/cljc/spec_tools/data_spec_test.cljc
+++ b/test/cljc/spec_tools/data_spec_test.cljc
@@ -12,7 +12,7 @@
         impl (#'ds/coll-of-spec string? [])]
     (is (= (s/form spec)
            (s/form impl)))
-    (is (= `(s/coll-of (st/spec string? {:type :string}) :into [])
+    (is (= `(s/coll-of (st/spec {:spec string? :type :string}) :into [])
            (s/form (#'ds/coll-of-spec spec/string? []))))
     (is (= nil
            (s/explain-data spec ["1"])
@@ -30,8 +30,8 @@
     (is (= (s/form spec)
            (s/form impl)))
     (is (= `(s/map-of
-              (st/spec string? {:type :string})
-              (st/spec string? {:type :string})
+              (st/spec {:spec string? :type :string})
+              (st/spec {:spec string? :type :string})
               :conform-keys true)
            (s/form (#'ds/map-of-spec spec/string? spec/string?))))
     (is (= nil
@@ -73,7 +73,7 @@
         impl (#'ds/nilable-spec string?)]
     (is (= (s/form spec)
            (s/form impl)))
-    (is (= `(s/nilable (st/spec string? {:type :string}))
+    (is (= `(s/nilable (st/spec {:spec string? :type :string}))
            (s/form (#'ds/nilable-spec spec/string?))))
     (is (= nil
            (s/explain-data spec "1")


### PR DESCRIPTION
* Better `s/describe*` for Spec Records
* Spec Records retain `::s/name` from underlaying specs
