### PR TITLE
Extendable Visitors (-> 0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 * visitor (and by so, json-schema generation) supports also direct predicate specs, via form inference:
 
+* added `spec-tools.core/spec-name`, to resolve spec name, like `clojure.spec.alpha/spec-name` but non-private & understands Spec Records.
+
+* JSON Schema generation set `:title` for Object Schemas based on `st/spec-name`.
+
 ```clj
 (require '[spec-tools.json-schema :as json-schema])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * visitor (and by so, json-schema generation) supports also direct predicate specs, via form inference:
 
 * added `spec-tools.core/spec-name`, to resolve spec name, like `clojure.spec.alpha/spec-name` but non-private & understands Spec Records.
+* added `spec-tools.core/spec-description`, to resolve spec description, understands Spec Records.
 
 * JSON Schema generation set `:title` for Object Schemas based on `st/spec-name`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,10 @@
 * **BREAKING**: More configurable Spec Visitor
   * `spec-tools.visitor/visit takes optionally 4th argument, an options-map, passed into all sub-visits & accepts
   * changed the extension multimethod from `visit` to `visit-spec` (to better support static analysis for arity errors)
-  * the `accept` function is not 4-arity (was 3-arity), taking the options-map as 4th argument
+  * the `accept` function is now 4-arity (was 3-arity), taking the options-map as 4th argument
   * the `spec-tools.json-schema/transform` also has optional 4-arity with the options-map as 4th argument
 
 * visitor (and by so, json-schema generation) supports also direct predicate specs, via form inference:
-
-* added `spec-tools.core/spec-name`, to resolve spec name, like `clojure.spec.alpha/spec-name` but non-private & understands Spec Records.
-* added `spec-tools.core/spec-description`, to resolve spec description, understands Spec Records.
-
-* JSON Schema generation set `:title` for Object Schemas based on `st/spec-name`.
 
 ```clj
 (require '[spec-tools.json-schema :as json-schema])
@@ -20,6 +15,10 @@
 ; {:type "integer", :format "int64"}
 ```
 
+* added `spec-tools.core/spec-name`, to resolve spec name, like `clojure.spec.alpha/spec-name` but non-private & understands Spec Records.
+* added `spec-tools.core/spec-description`, to resolve spec description, understands Spec Records.
+
+* JSON Schema generation set `:title` for Object Schemas based on `st/spec-name`.
 
 ## 0.2.2 (2017-06-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## UNRELEASED
+
+* **BREAKING**: More configurable Spec Visitor
+  * `spec-tools.visitor/visit takes optionally 4th argument, an options-map, passed into all sub-visits & accepts
+  * changed the extension multimethod from `visit` to `visit-spec` (to better support static analysis for arity errors)
+  * the `accept` function is not 4-arity (was 3-arity), taking the options-map as 4th argument
+  * the `spec-tools.json-schema/transform` also has optional 4-arity with the options-map as 4th argument
+
+* visitor (and by so, json-schema generation) supports also direct predicate specs, via form inference:
+
+```clj
+(require '[spec-tools.json-schema :as json-schema])
+
+(json-schema/transform int?)
+; {:type "integer", :format "int64"}
+```
+
+
 ## 0.2.2 (2017-06-12)
 
 * Spec Record `describe*` uses the map syntax, e.g. `(st/spec clojure.core/string? {}` => `(st/spec {:spec clojure.core/string?})`

--- a/README.md
+++ b/README.md
@@ -409,16 +409,16 @@ Data Specs offers an alternative, Schema-like data-driven syntax to define simpl
 
 ### Spec Visitors
 
-A tool to walk over and transform specs using the [Visitor-pattern](https://en.wikipedia.org/wiki/Visitor_pattern). There is a example visitor to collect all the registered specs linked to a spec. The [JSON Schema -generation](#generating-json-schemas) uses this.
+A tool to walk over and transform specs using the [Visitor-pattern](https://en.wikipedia.org/wiki/Visitor_pattern). Main entry point is the `spec-tools.visitor/visit` function, extendable via `spec-tools.visitor/visit-spec` multimethod. There is an example implementation for recursively collecting nested specs. Also, the [Spec to JSON Schema -converter](#generating-json-schemas) is implemented using the visitor.
 
 ```clj
 (require '[spec-tools.visitor :as visitor])
 
-;; visitor to collect all registered specs
+;; visitor to recursively collect all registered spec forms
 (let [specs (atom {})]
   (visitor/visit
     person-spec
-    (fn [_ spec _]
+    (fn [_ spec _ _]
       (if-let [s (s/get-spec spec)]
         (swap! specs assoc spec (s/form s))
         @specs))))

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/spec-tools "0.2.3-SNAPSHOT"
+(defproject metosin/spec-tools "0.3.0-SNAPSHOT"
   :description "Clojure(Script) tools for clojure.spec"
   :url "https://github.com/metosin/spec-tools"
   :license {:name "Eclipse Public License"

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -233,7 +233,17 @@
 
     #?(:clj  (instance? clojure.lang.IObj spec)
        :cljs (implements? IMeta spec))
-    (-> (meta spec) ::s/name)))
+    (-> (meta spec) ::s/name)
+
+    :else nil))
+
+(defn spec-description
+  "Returns a spec description."
+  [spec]
+  (cond
+    (and (spec? spec) (:description spec)) (:description spec)
+
+    :else nil))
 
 ;; TODO: use http://dev.clojure.org/jira/browse/CLJ-2112
 (defmulti collect-info (fn [dispath _] dispath) :default ::default)

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -221,6 +221,20 @@
 (defn spec? [x]
   (if (instance? Spec x) x))
 
+(defn spec-name
+  "Returns a spec name. Like the private clojure.spec.alpha/spec-name"
+  [spec]
+  (cond
+    (ident? spec) spec
+
+    (s/regex? spec) (::s/name spec)
+
+    (and (spec? spec) (:name spec)) (:name spec)
+
+    #?(:clj  (instance? clojure.lang.IObj spec)
+       :cljs (implements? IMeta spec))
+    (-> (meta spec) ::s/name)))
+
 ;; TODO: use http://dev.clojure.org/jira/browse/CLJ-2112
 (defmulti collect-info (fn [dispath _] dispath) :default ::default)
 (defmethod collect-info ::default [_ _] nil)

--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -255,7 +255,10 @@
 ; &
 
 (defmethod accept-spec 'clojure.spec.alpha/tuple [_ _ children _]
-  {:type "array" :items children :minItems (count children)})
+  {:type "array"
+   :items children
+   :minItems (count children)
+   :maxItems (count children)})
 
 ; keys*
 

--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -184,7 +184,7 @@
 (defmethod accept-spec ::visitor/set [dispatch spec children _]
   {:enum children})
 
-(defn maybe-with-title [schema spec]
+(defn- maybe-with-title [schema spec]
   (if-let [title (st/spec-name spec)]
     (assoc schema :title (visitor/namespaced-name title))
     schema))

--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -23,11 +23,6 @@
 
 (defn- spec-dispatch [dispatch _ _ _] dispatch)
 
-(defn- namespaced-name [key]
-  (if-let [nn (namespace key)]
-    (str nn "/" (name key))
-    (name key)))
-
 (defmulti accept-spec spec-dispatch :default ::default)
 
 (defn transform
@@ -191,14 +186,14 @@
 
 (defn maybe-with-title [schema spec]
   (if-let [title (st/spec-name spec)]
-    (assoc schema :title (namespaced-name title))
+    (assoc schema :title (visitor/namespaced-name title))
     schema))
 
 (defmethod accept-spec 'clojure.spec.alpha/keys [_ spec children _]
   (let [[_ & {:keys [req req-un opt opt-un]}] (visitor/extract-form spec)
         names-un    (map name (concat req-un opt-un))
-        names       (map namespaced-name (concat req opt))
-        required    (map namespaced-name req)
+        names       (map visitor/namespaced-name (concat req opt))
+        required    (map visitor/namespaced-name req)
         required-un (map name req-un)]
     (maybe-with-title
       {:type "object"

--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -15,12 +15,6 @@
       (and (= (count subspecs) 1) (only-entry? :allOf spec)) (first subspecs)
       :else (assoc spec :allOf subspecs))))
 
-(defn- unwrap
-  "Unwrap [x] to x. Asserts that coll has exactly one element."
-  [coll]
-  {:pre [(= 1 (count coll))]}
-  (first coll))
-
 (defn- spec-dispatch [dispatch _ _ _] dispatch)
 
 (defmulti accept-spec spec-dispatch :default ::default)
@@ -216,9 +210,9 @@
   (let [form (visitor/extract-form spec)
         type (type/resolve-type form)]
     (case type
-      :map (maybe-with-title {:type "object", :additionalProperties (unwrap children)} spec)
-      :set {:type "array", :uniqueItems true, :items (unwrap children)}
-      :vector {:type "array", :items (unwrap children)})))
+      :map (maybe-with-title {:type "object", :additionalProperties (visitor/unwrap children)} spec)
+      :set {:type "array", :uniqueItems true, :items (visitor/unwrap children)}
+      :vector {:type "array", :items (visitor/unwrap children)})))
 
 (defmethod accept-spec 'clojure.spec.alpha/every-kv [_ spec children _]
   (maybe-with-title {:type "object", :additionalProperties (second children)} spec))
@@ -227,19 +221,19 @@
   (maybe-with-title {:type "object", :additionalProperties (second children)} spec))
 
 (defmethod accept-spec ::visitor/set-of [_ _ children _]
-  {:type "array", :items (unwrap children), :uniqueItems true})
+  {:type "array", :items (visitor/unwrap children), :uniqueItems true})
 
 (defmethod accept-spec ::visitor/vector-of [_ _ children _]
-  {:type "array", :items (unwrap children)})
+  {:type "array", :items (visitor/unwrap children)})
 
 (defmethod accept-spec 'clojure.spec.alpha/* [_ _ children _]
-  {:type "array" :items (unwrap children)})
+  {:type "array" :items (visitor/unwrap children)})
 
 (defmethod accept-spec 'clojure.spec.alpha/+ [_ _ children _]
-  {:type "array" :items (unwrap children) :minItems 1})
+  {:type "array" :items (visitor/unwrap children) :minItems 1})
 
 (defmethod accept-spec 'clojure.spec.alpha/? [_ _ children _]
-  {:type "array" :items (unwrap children) :minItems 0})
+  {:type "array" :items (visitor/unwrap children) :minItems 0})
 
 (defmethod accept-spec 'clojure.spec.alpha/alt [_ _ children _]
   {:anyOf children})
@@ -261,7 +255,7 @@
 ; keys*
 
 (defmethod accept-spec 'clojure.spec.alpha/nilable [_ _ children _]
-  {:oneOf [(unwrap children) {:type "null"}]})
+  {:oneOf [(visitor/unwrap children) {:type "null"}]})
 
 ;; this is just a function in clojure.spec?
 (defmethod accept-spec 'clojure.spec.alpha/int-in-range? [_ spec _ _]
@@ -280,7 +274,7 @@
         extra-info (-> data
                        (select-keys [:name :description])
                        (set/rename-keys {:name :title}))]
-    (merge (unwrap children) extra-info json-schema-meta)))
+    (merge (visitor/unwrap children) extra-info json-schema-meta)))
 
 (defmethod accept-spec ::default [_ _ _ _]
   {})

--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -1,7 +1,6 @@
 (ns spec-tools.json-schema
   "Tools for converting specs into JSON Schemata."
-  (:require [clojure.spec.alpha :as s]
-            [spec-tools.visitor :as visitor :refer [visit]]
+  (:require [spec-tools.visitor :as visitor]
             [spec-tools.type :as type]
             [clojure.set :as set]))
 
@@ -20,95 +19,100 @@
   {:pre [(= 1 (count coll))]}
   (first coll))
 
-(defn- spec-dispatch [dispatch spec children] dispatch)
+
+(defn- spec-dispatch [dispatch _ _ _] dispatch)
 
 (defn- namespaced-name [key] (str (namespace key) "/" (name key)))
 
 (defmulti accept-spec spec-dispatch :default ::default)
 
-(defn transform [spec] (visit spec accept-spec))
+(defn transform
+  ([spec]
+   (transform spec nil))
+  ([spec options]
+   (visitor/visit spec accept-spec options)))
 
 ;;
 ;; predicate list taken from https://github.com/clojure/clojure/blob/master/src/clj/clojure/spec/gen.clj
 ;;
 
 ; any? (one-of [(return nil) (any-printable)])
-(defmethod accept-spec 'clojure.core/any? [_ _ _] {})
+(defmethod accept-spec 'clojure.core/any? [_ _ _ _] {})
 
 ; some? (such-that some? (any-printable))
-(defmethod accept-spec 'clojure.core/some? [_ _ _] {})
+(defmethod accept-spec 'clojure.core/some? [_ _ _ _] {})
 
 ; number? (one-of [(large-integer) (double)])
-(defmethod accept-spec 'clojure.core/number? [_ _ _] {:type "number" :format "double"})
+(defmethod accept-spec 'clojure.core/number? [_ _ _ _] {:type "number" :format "double"})
 
 ; integer? (large-integer)
-(defmethod accept-spec 'clojure.core/integer? [_ _ _] {:type "integer"})
+(defmethod accept-spec 'clojure.core/integer? [_ _ _ _] {:type "integer"})
 
 ; int? (large-integer)
-(defmethod accept-spec 'clojure.core/int? [_ _ _] {:type "integer" :format "int64"})
+(defmethod accept-spec 'clojure.core/int? [_ _ _ _] {:type "integer" :format "int64"})
 
 ; pos-int? (large-integer* {:min 1})
-(defmethod accept-spec 'clojure.core/pos-int? [_ _ _] {:type "integer", :format "int64", :minimum 1})
+(defmethod accept-spec 'clojure.core/pos-int? [_ _ _ _] {:type "integer", :format "int64", :minimum 1})
 
 ; neg-int? (large-integer* {:max -1})
-(defmethod accept-spec 'clojure.core/neg-int? [_ _ _] {:type "integer", :format "int64", :maximum -1})
+(defmethod accept-spec 'clojure.core/neg-int? [_ _ _ _] {:type "integer", :format "int64", :maximum -1})
 
 ; nat-int? (large-integer* {:min 0})
-(defmethod accept-spec 'clojure.core/nat-int? [_ _ _] {:type "integer", :format "int64" :minimum 0})
+(defmethod accept-spec 'clojure.core/nat-int? [_ _ _ _] {:type "integer", :format "int64" :minimum 0})
 
 ; float? (double)
-(defmethod accept-spec 'clojure.core/float? [_ _ _] {:type "number"})
+(defmethod accept-spec 'clojure.core/float? [_ _ _ _] {:type "number"})
 
 ; double? (double)
-(defmethod accept-spec 'clojure.core/double? [_ _ _] {:type "number"})
+(defmethod accept-spec 'clojure.core/double? [_ _ _ _] {:type "number"})
 
 ; boolean? (boolean)
-(defmethod accept-spec 'clojure.core/boolean? [_ _ _] {:type "boolean"})
+(defmethod accept-spec 'clojure.core/boolean? [_ _ _ _] {:type "boolean"})
 
 ; string? (string-alphanumeric)
-(defmethod accept-spec 'clojure.core/string? [_ _ _] {:type "string"})
+(defmethod accept-spec 'clojure.core/string? [_ _ _ _] {:type "string"})
 
 ; ident? (one-of [(keyword-ns) (symbol-ns)])
-(defmethod accept-spec 'clojure.core/ident? [_ _ _] {:type "string"})
+(defmethod accept-spec 'clojure.core/ident? [_ _ _ _] {:type "string"})
 
 ; simple-ident? (one-of [(keyword) (symbol)])
-(defmethod accept-spec 'clojure.core/simple-ident? [_ _ _] {:type "string"})
+(defmethod accept-spec 'clojure.core/simple-ident? [_ _ _ _] {:type "string"})
 
 ; qualified-ident? (such-that qualified? (one-of [(keyword-ns) (symbol-ns)]))
-(defmethod accept-spec 'clojure.core/qualified-ident? [_ _ _] {:type "string"})
+(defmethod accept-spec 'clojure.core/qualified-ident? [_ _ _ _] {:type "string"})
 
 ; keyword? (keyword-ns)
-(defmethod accept-spec 'clojure.core/keyword? [_ _ _] {:type "string"})
+(defmethod accept-spec 'clojure.core/keyword? [_ _ _ _] {:type "string"})
 
 ; simple-keyword? (keyword)
-(defmethod accept-spec 'clojure.core/simple-keyword? [_ _ _] {:type "string"})
+(defmethod accept-spec 'clojure.core/simple-keyword? [_ _ _ _] {:type "string"})
 
 ; qualified-keyword? (such-that qualified? (keyword-ns))
-(defmethod accept-spec 'clojure.core/qualified-keyword? [_ _ _] {:type "string"})
+(defmethod accept-spec 'clojure.core/qualified-keyword? [_ _ _ _] {:type "string"})
 
 ; symbol? (symbol-ns)
-(defmethod accept-spec 'clojure.core/symbol? [_ _ _] {:type "string"})
+(defmethod accept-spec 'clojure.core/symbol? [_ _ _ _] {:type "string"})
 
 ; simple-symbol? (symbol)
-(defmethod accept-spec 'clojure.core/simple-symbol? [_ _ _] {:type "string"})
+(defmethod accept-spec 'clojure.core/simple-symbol? [_ _ _ _] {:type "string"})
 
 ; qualified-symbol? (such-that qualified? (symbol-ns))
-(defmethod accept-spec 'clojure.core/qualified-symbol? [_ _ _] {:type "string"})
+(defmethod accept-spec 'clojure.core/qualified-symbol? [_ _ _ _] {:type "string"})
 
 ; uuid? (uuid)
-(defmethod accept-spec 'clojure.core/uuid? [_ _ _] {:type "string" :format "uuid"})
+(defmethod accept-spec 'clojure.core/uuid? [_ _ _ _] {:type "string" :format "uuid"})
 
 ; uri? (fmap #(java.net.URI/create (str "http://" % ".com")) (uuid))
-(defmethod accept-spec 'clojure.core/uri? [_ _ _] {:type "string" :format "uri"})
+(defmethod accept-spec 'clojure.core/uri? [_ _ _ _] {:type "string" :format "uri"})
 
 ; bigdec? (fmap #(BigDecimal/valueOf %)
 ;               (double* {:infinite? false :NaN? false}))
-(defmethod accept-spec 'clojure.core/bigdec? [_ _ _] {:type "number" :format "double"})
+(defmethod accept-spec 'clojure.core/bigdec? [_ _ _ _] {:type "number" :format "double"})
 
 
 ; inst? (fmap #(java.util.Date. %)
 ;             (large-integer))
-(defmethod accept-spec 'clojure.core/bigdec? [_ _ _] {:type "number" :format "double"})
+(defmethod accept-spec 'clojure.core/bigdec? [_ _ _ _] {:type "number" :format "double"})
 
 ; seqable? (one-of [(return nil)
 ;                   (list simple)
@@ -116,72 +120,72 @@
 ;                   (map simple simple)
 ;                   (set simple)
 ;                   (string-alphanumeric)])
-(defmethod accept-spec 'clojure.core/seqable? [_ _ _] {:type "array"})
+(defmethod accept-spec 'clojure.core/seqable? [_ _ _ _] {:type "array"})
 
 ; indexed? (vector simple)
-(defmethod accept-spec 'clojure.core/map? [_ _ _] {:type "array"})
+(defmethod accept-spec 'clojure.core/map? [_ _ _ _] {:type "array"})
 
 ; map? (map simple simple)
-(defmethod accept-spec 'clojure.core/map? [_ _ _] {:type "object"})
+(defmethod accept-spec 'clojure.core/map? [_ _ _ _] {:type "object"})
 
 ; vector? (vector simple)
-(defmethod accept-spec 'clojure.core/vector? [_ _ _] {:type "array"})
+(defmethod accept-spec 'clojure.core/vector? [_ _ _ _] {:type "array"})
 
 ; list? (list simple)
-(defmethod accept-spec 'clojure.core/list? [_ _ _] {:type "array"})
+(defmethod accept-spec 'clojure.core/list? [_ _ _ _] {:type "array"})
 
 ; seq? (list simple)
-(defmethod accept-spec 'clojure.core/seq? [_ _ _] {:type "array"})
+(defmethod accept-spec 'clojure.core/seq? [_ _ _ _] {:type "array"})
 
 ; char? (char)
-(defmethod accept-spec 'clojure.core/char? [_ _ _] {:type "string"})
+(defmethod accept-spec 'clojure.core/char? [_ _ _ _] {:type "string"})
 
 ; set? (set simple)
-(defmethod accept-spec 'clojure.core/set? [_ _ _] {:type "array" :uniqueItems true})
+(defmethod accept-spec 'clojure.core/set? [_ _ _ _] {:type "array" :uniqueItems true})
 
 ; nil? (return nil)
-(defmethod accept-spec 'clojure.core/nil? [_ _ _] {:type "null"})
+(defmethod accept-spec 'clojure.core/nil? [_ _ _ _] {:type "null"})
 
 ; false? (return false)
-(defmethod accept-spec 'clojure.core/false? [_ _ _] {:type "boolean"})
+(defmethod accept-spec 'clojure.core/false? [_ _ _ _] {:type "boolean"})
 
 ; true? (return true)
-(defmethod accept-spec 'clojure.core/true? [_ _ _] {:type "boolean"})
+(defmethod accept-spec 'clojure.core/true? [_ _ _ _] {:type "boolean"})
 
 ; zero? (return 0)
-(defmethod accept-spec 'clojure.core/zero? [_ _ _] {:type "integer"})
+(defmethod accept-spec 'clojure.core/zero? [_ _ _ _] {:type "integer"})
 
 ; rational? (one-of [(large-integer) (ratio)])
-(defmethod accept-spec 'clojure.core/coll? [_ _ _] {:type "double"})
+(defmethod accept-spec 'clojure.core/coll? [_ _ _ _] {:type "double"})
 
 ; coll? (one-of [(map simple simple)
 ;                (list simple)
 ;                (vector simple)
 ;                (set simple)])
-(defmethod accept-spec 'clojure.core/coll? [_ _ _] {:type "object"})
+(defmethod accept-spec 'clojure.core/coll? [_ _ _ _] {:type "object"})
 
 ; empty? (elements [nil '() [] {} #{}])
-(defmethod accept-spec 'clojure.core/empty? [_ _ _] {:type "array" :maxItems 0 :minItems 0})
+(defmethod accept-spec 'clojure.core/empty? [_ _ _ _] {:type "array" :maxItems 0 :minItems 0})
 
 ; associative? (one-of [(map simple simple) (vector simple)])
-(defmethod accept-spec 'clojure.core/associative? [_ _ _] {:type "object"})
+(defmethod accept-spec 'clojure.core/associative? [_ _ _ _] {:type "object"})
 
 ; sequential? (one-of [(list simple) (vector simple)])
-(defmethod accept-spec 'clojure.core/sequential? [_ _ _] {:type "array"})
+(defmethod accept-spec 'clojure.core/sequential? [_ _ _ _] {:type "array"})
 
 ; ratio? (such-that ratio? (ratio))
-(defmethod accept-spec 'clojure.core/ratio? [_ _ _] {:type "integer"})
+(defmethod accept-spec 'clojure.core/ratio? [_ _ _ _] {:type "integer"})
 
 ; bytes? (bytes)
-(defmethod accept-spec 'clojure.core/ratio? [_ _ _] {:type "string" :format "byte"})
+(defmethod accept-spec 'clojure.core/ratio? [_ _ _ _] {:type "string" :format "byte"})
 
-(defmethod accept-spec 'clojure.core/pos? [_ _ _] {:minimum 0 :exclusiveMinimum true})
-(defmethod accept-spec 'clojure.core/neg? [_ _ _] {:maximum 0 :exclusiveMaximum true})
+(defmethod accept-spec 'clojure.core/pos? [_ _ _ _] {:minimum 0 :exclusiveMinimum true})
+(defmethod accept-spec 'clojure.core/neg? [_ _ _ _] {:maximum 0 :exclusiveMaximum true})
 
-(defmethod accept-spec ::visitor/set [dispatch spec children]
+(defmethod accept-spec ::visitor/set [dispatch spec children _]
   {:enum children})
 
-(defmethod accept-spec 'clojure.spec.alpha/keys [dispatch spec children]
+(defmethod accept-spec 'clojure.spec.alpha/keys [_ spec children _]
   (let [[_ & {:keys [req req-un opt opt-un]}] (visitor/extract-form spec)
         names-un    (map name (concat req-un opt-un))
         names       (map namespaced-name (concat req opt))
@@ -191,18 +195,18 @@
      :properties (zipmap (concat names names-un) children)
      :required (vec (concat required required-un))}))
 
-(defmethod accept-spec 'clojure.spec.alpha/or [dispatch spec children]
+(defmethod accept-spec 'clojure.spec.alpha/or [_ _ children _]
   {:anyOf children})
 
-(defmethod accept-spec 'clojure.spec.alpha/and [dispatch spec children]
+(defmethod accept-spec 'clojure.spec.alpha/and [_ _ children _]
   (simplify-all-of {:allOf children}))
 
-(defmethod accept-spec 'clojure.spec.alpha/merge [dispatch spec children]
+(defmethod accept-spec 'clojure.spec.alpha/merge [_ _ children _]
   {:type "object"
    :properties (apply merge (map :properties children))
    :required (into [] (reduce into (sorted-set) (map :required children)))})
 
-(defmethod accept-spec 'clojure.spec.alpha/every [dispatch spec children]
+(defmethod accept-spec 'clojure.spec.alpha/every [_ spec children _]
   (let [form (visitor/extract-form spec)
         type (type/resolve-type form)]
     (case type
@@ -210,31 +214,31 @@
       :set {:type "array", :uniqueItems true, :items (unwrap children)}
       :vector {:type "array", :items (unwrap children)})))
 
-(defmethod accept-spec 'clojure.spec.alpha/every-kv [dispatch spec children]
+(defmethod accept-spec 'clojure.spec.alpha/every-kv [_ _ children _]
   {:type "object", :additionalProperties (second children)})
 
-(defmethod accept-spec ::visitor/map-of [dispatch spec children]
+(defmethod accept-spec ::visitor/map-of [_ _ children _]
   {:type "object", :additionalProperties (second children)})
 
-(defmethod accept-spec ::visitor/set-of [dispatch spec children]
+(defmethod accept-spec ::visitor/set-of [_ _ children _]
   {:type "array", :items (unwrap children), :uniqueItems true})
 
-(defmethod accept-spec ::visitor/vector-of [dispatch spec children]
+(defmethod accept-spec ::visitor/vector-of [_ _ children _]
   {:type "array", :items (unwrap children)})
 
-(defmethod accept-spec 'clojure.spec.alpha/* [dispatch spec children]
+(defmethod accept-spec 'clojure.spec.alpha/* [_ _ children _]
   {:type "array" :items (unwrap children)})
 
-(defmethod accept-spec 'clojure.spec.alpha/+ [dispatch spec children]
+(defmethod accept-spec 'clojure.spec.alpha/+ [_ _ children _]
   {:type "array" :items (unwrap children) :minItems 1})
 
-(defmethod accept-spec 'clojure.spec.alpha/? [dispatch spec children]
+(defmethod accept-spec 'clojure.spec.alpha/? [_ _ children _]
   {:type "array" :items (unwrap children) :minItems 0})
 
-(defmethod accept-spec 'clojure.spec.alpha/alt [dispatch spec children]
+(defmethod accept-spec 'clojure.spec.alpha/alt [_ _ children _]
   {:anyOf children})
 
-(defmethod accept-spec 'clojure.spec.alpha/cat [dispatch spec children]
+(defmethod accept-spec 'clojure.spec.alpha/cat [_ _ children _]
   {:type "array"
    :minItems (count children)
    :maxItems (count children)
@@ -242,20 +246,20 @@
 
 ; &
 
-(defmethod accept-spec 'clojure.spec.alpha/tuple [dispatch spec children]
+(defmethod accept-spec 'clojure.spec.alpha/tuple [_ _ children _]
   {:type "array" :items children :minItems (count children)})
 
 ; keys*
 
-(defmethod accept-spec 'clojure.spec.alpha/nilable [dispatch spec children]
+(defmethod accept-spec 'clojure.spec.alpha/nilable [_ _ children _]
   {:oneOf [(unwrap children) {:type "null"}]})
 
 ;; this is just a function in clojure.spec?
-(defmethod accept-spec 'clojure.spec.alpha/int-in-range? [dispatch spec children]
+(defmethod accept-spec 'clojure.spec.alpha/int-in-range? [_ spec _ _]
   (let [[_ minimum maximum _] (visitor/strip-fn-if-needed spec)]
     {:minimum minimum :maximum maximum}))
 
-(defmethod accept-spec ::visitor/spec [dispatch spec children]
+(defmethod accept-spec ::visitor/spec [_ spec children _]
   (let [[_ data] (visitor/extract-form spec)
         json-schema-meta (reduce-kv
                            (fn [acc k v]
@@ -269,5 +273,5 @@
                        (set/rename-keys {:name :title}))]
     (merge (unwrap children) extra-info json-schema-meta)))
 
-(defmethod accept-spec ::default [dispatch spec children]
+(defmethod accept-spec ::default [_ spec _ _]
   {})

--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -216,9 +216,7 @@
   (let [form (visitor/extract-form spec)
         type (type/resolve-type form)]
     (case type
-      :map (maybe-with-title
-             {:type "object", :additionalProperties (unwrap children)}
-             spec)
+      :map (maybe-with-title {:type "object", :additionalProperties (unwrap children)} spec)
       :set {:type "array", :uniqueItems true, :items (unwrap children)}
       :vector {:type "array", :items (unwrap children)})))
 

--- a/src/spec_tools/visitor.cljc
+++ b/src/spec_tools/visitor.cljc
@@ -3,7 +3,8 @@
   (:require [clojure.spec.alpha :as s]
             [spec-tools.core :as st]
             [spec-tools.type :as type]
-            [spec-tools.impl :as impl]))
+            [spec-tools.impl :as impl]
+            [spec-tools.form :as form]))
 
 (defn strip-fn-if-needed [form]
   (let [head (first form)]
@@ -23,69 +24,73 @@
   (if (seq? spec) spec (s/form spec)))
 
 (defn- spec-dispatch
-  [spec accept]
+  [spec accept options]
   (cond
     (or (s/spec? spec) (s/regex? spec) (keyword? spec))
     (let [form (s/form spec)]
       (if (not= form ::s/unknown)
         (if (seq? form)
           (normalize-symbol (first form))
-          (spec-dispatch form accept))
+          (spec-dispatch form accept options))
         spec))
     (set? spec) ::set
     (seq? spec) (normalize-symbol (first (strip-fn-if-needed spec)))
-    :else (normalize-symbol spec)))
+    (symbol? spec) (normalize-symbol spec)
+    :else (form/resolve-form spec)))
 
-(defn- expand-spec-ns [x]
-  (if-not (namespace x) (symbol "clojure.core" (name x)) x))
+(defmulti visit-spec spec-dispatch :default ::default)
 
-(defmulti visit
-  "Walk a spec definition. Takes two arguments, the spec and the accept
-  function, and returns the result of calling the accept function.
+(defn visit
+  "Walk a spec definition. Takes 2-3 arguments, the spec and the accept
+  function, and optionally a options map, and returns the result of
+  calling the accept function.
 
-  The accept function is called with three arguments: the dispatch term for the
-  spec (see below), the spec itself and the vector with the results of
-  recursively walking the children of the spec.
+  The accept function is called with 4 arguments: the dispatch term for the
+  spec (see below), the spec itself, vector with the results of
+  recursively walking the children of the spec and the options map.
 
   The dispatch term is one of the following
   * if the spec is a function call: a fully qualified symbol for the function
     with the following exceptions:
     - cljs.core symbols are converted to clojure.core symbols
-    - cljs.spec.alpha symbols are converted to clojure.spec symbols
+    - cljs.spec.alpha symbols are converted to clojure.spec.alpha symbols
   * if the spec is a set: :spec-tools.visitor/set
   * otherwise: the spec itself"
-  spec-dispatch :default ::default)
+  ([spec accept]
+    (visit spec accept nil))
+  ([spec accept options]
+    (visit-spec spec accept options)))
 
-(defmethod visit ::set [spec accept]
-  (accept ::set spec (vec (if (keyword? spec) (extract-form spec) spec))))
+(defmethod visit-spec ::set [spec accept options]
+  (accept ::set spec (vec (if (keyword? spec) (extract-form spec) spec)) options))
 
-(defmethod visit 'clojure.spec.alpha/keys [spec accept]
+(defmethod visit-spec 'clojure.spec.alpha/keys [spec accept options]
   (let [keys (impl/extract-keys (extract-form spec))]
-    (accept 'clojure.spec.alpha/keys spec (mapv #(visit % accept) keys))))
+    (accept 'clojure.spec.alpha/keys spec (mapv #(visit-spec % accept options) keys) options)))
 
-(defmethod visit 'clojure.spec.alpha/or [spec accept]
+(defmethod visit-spec 'clojure.spec.alpha/or [spec accept options]
   (let [[_ & {:as inner-spec-map}] (extract-form spec)]
-    (accept 'clojure.spec.alpha/or spec (mapv #(visit % accept) (vals inner-spec-map)))))
+    (accept 'clojure.spec.alpha/or spec (mapv #(visit-spec % accept options) (vals inner-spec-map)) options)))
 
-(defmethod visit 'clojure.spec.alpha/and [spec accept]
+(defmethod visit-spec 'clojure.spec.alpha/and [spec accept options]
   (let [[_ & inner-specs] (extract-form spec)]
-    (accept 'clojure.spec.alpha/and spec (mapv #(visit % accept) inner-specs))))
+    (accept 'clojure.spec.alpha/and spec (mapv #(visit-spec % accept options) inner-specs) options)))
 
-(defmethod visit 'clojure.spec.alpha/merge [spec accept]
+(defmethod visit-spec 'clojure.spec.alpha/merge [spec accept options]
   (let [[_ & inner-specs] (extract-form spec)]
-    (accept 'clojure.spec.alpha/merge spec (mapv #(visit % accept) inner-specs))))
+    (accept 'clojure.spec.alpha/merge spec (mapv #(visit-spec % accept options) inner-specs) options)))
 
-(defmethod visit 'clojure.spec.alpha/every [spec accept]
+(defmethod visit-spec 'clojure.spec.alpha/every [spec accept options]
   (let [[_ inner-spec] (extract-form spec)]
-    (accept 'clojure.spec.alpha/every spec [(visit inner-spec accept)])))
+    (accept 'clojure.spec.alpha/every spec [(visit-spec inner-spec accept options)] options)))
 
-(defmethod visit 'clojure.spec.alpha/every-kv [spec accept]
+(defmethod visit-spec 'clojure.spec.alpha/every-kv [spec accept options]
   (let [[_ inner-spec1 inner-spec2] (extract-form spec)]
     (accept 'clojure.spec.alpha/every-kv spec (mapv
-                                          #(visit % accept)
-                                          [inner-spec1 inner-spec2]))))
+                                                #(visit-spec % accept options)
+                                                [inner-spec1 inner-spec2]) options)))
 
-(defmethod visit 'clojure.spec.alpha/coll-of [spec accept]
+(defmethod visit-spec 'clojure.spec.alpha/coll-of [spec accept options]
   (let [form (extract-form spec)
         pred (second form)
         type (type/resolve-type form)
@@ -93,55 +98,55 @@
                    :map ::map-of
                    :set ::set-of
                    :vector ::vector-of)]
-    (accept dispatch spec [(visit pred accept)])))
+    (accept dispatch spec [(visit-spec pred accept options)] options)))
 
-(defmethod visit 'clojure.spec.alpha/map-of [spec accept]
+(defmethod visit-spec 'clojure.spec.alpha/map-of [spec accept options]
   (let [[_ k v] (extract-form spec)]
-    (accept ::map-of spec (mapv #(visit % accept) [k v]))))
+    (accept ::map-of spec (mapv #(visit-spec % accept options) [k v]) options)))
 
-(defmethod visit 'clojure.spec.alpha/* [spec accept]
+(defmethod visit-spec 'clojure.spec.alpha/* [spec accept options]
   (let [[_ inner-spec] (extract-form spec)]
-    (accept 'clojure.spec.alpha/* spec [(visit inner-spec accept)])))
+    (accept 'clojure.spec.alpha/* spec [(visit-spec inner-spec accept options)] options)))
 
-(defmethod visit 'clojure.spec.alpha/+ [spec accept]
+(defmethod visit-spec 'clojure.spec.alpha/+ [spec accept options]
   (let [[_ inner-spec] (extract-form spec)]
-    (accept 'clojure.spec.alpha/+ spec [(visit inner-spec accept)])))
+    (accept 'clojure.spec.alpha/+ spec [(visit-spec inner-spec accept options)] options)))
 
-(defmethod visit 'clojure.spec.alpha/? [spec accept]
+(defmethod visit-spec 'clojure.spec.alpha/? [spec accept options]
   (let [[_ inner-spec] (extract-form spec)]
-    (accept 'clojure.spec.alpha/? spec [(visit inner-spec accept)])))
+    (accept 'clojure.spec.alpha/? spec [(visit-spec inner-spec accept options)] options)))
 
-(defmethod visit 'clojure.spec.alpha/alt [spec accept]
+(defmethod visit-spec 'clojure.spec.alpha/alt [spec accept options]
   (let [[_ & {:as inner-spec-map}] (extract-form spec)]
-    (accept 'clojure.spec.alpha/alt spec (mapv #(visit % accept) (vals inner-spec-map)))))
+    (accept 'clojure.spec.alpha/alt spec (mapv #(visit-spec % accept options) (vals inner-spec-map)) options)))
 
-(defmethod visit 'clojure.spec.alpha/cat [spec accept]
+(defmethod visit-spec 'clojure.spec.alpha/cat [spec accept options]
   (let [[_ & {:as inner-spec-map}] (extract-form spec)]
-    (accept 'clojure.spec.alpha/cat spec (mapv #(visit % accept) (vals inner-spec-map)))))
+    (accept 'clojure.spec.alpha/cat spec (mapv #(visit-spec % accept options) (vals inner-spec-map)) options)))
 
-(defmethod visit 'clojure.spec.alpha/& [spec accept]
+(defmethod visit-spec 'clojure.spec.alpha/& [spec accept options]
   (let [[_ inner-spec] (extract-form spec)]
-    (accept 'clojure.spec.alpha/& spec [(visit inner-spec accept)])))
+    (accept 'clojure.spec.alpha/& spec [(visit-spec inner-spec accept options)] options)))
 
-(defmethod visit 'clojure.spec.alpha/tuple [spec accept]
+(defmethod visit-spec 'clojure.spec.alpha/tuple [spec accept options]
   (let [[_ & inner-specs] (extract-form spec)]
-    (accept 'clojure.spec.alpha/tuple spec (mapv #(visit % accept) inner-specs))))
+    (accept 'clojure.spec.alpha/tuple spec (mapv #(visit-spec % accept options) inner-specs) options)))
 
 ;; TODO: broken: http://dev.clojure.org/jira/browse/CLJ-2147
-(defmethod visit 'clojure.spec.alpha/keys* [spec accept]
+(defmethod visit-spec 'clojure.spec.alpha/keys* [spec accept options]
   (let [keys (impl/extract-keys (extract-form spec))]
-    (accept 'clojure.spec.alpha/keys* spec (mapv #(visit % accept) keys))))
+    (accept 'clojure.spec.alpha/keys* spec (mapv #(visit-spec % accept options) keys) options)))
 
-(defmethod visit 'clojure.spec.alpha/nilable [spec accept]
+(defmethod visit-spec 'clojure.spec.alpha/nilable [spec accept options]
   (let [[_ inner-spec] (extract-form spec)]
-    (accept 'clojure.spec.alpha/nilable spec [(visit inner-spec accept)])))
+    (accept 'clojure.spec.alpha/nilable spec [(visit-spec inner-spec accept options)] options)))
 
-(defmethod visit 'spec-tools.core/spec [spec accept]
+(defmethod visit-spec 'spec-tools.core/spec [spec accept options]
   (let [[_ {inner-spec :spec}] (extract-form spec)]
-    (accept ::spec spec [(visit inner-spec accept)])))
+    (accept ::spec spec [(visit-spec inner-spec accept options)] options)))
 
-(defmethod visit ::default [spec accept]
-  (accept (spec-dispatch spec accept) spec nil))
+(defmethod visit-spec ::default [spec accept options]
+  (accept (spec-dispatch spec accept options) spec nil options))
 
 ;;
 ;; sample visitor
@@ -149,10 +154,10 @@
 
 (defn spec-collector
   "a visitor that collects all registered specs. Returns
-  a map of spec-name => specs"
+  a map of spec-name => spec."
   []
   (let [specs (atom {})]
-    (fn [_ spec _]
+    (fn [_ spec _ _]
       (if-let [s (s/get-spec spec)]
         (swap! specs assoc spec s)
         @specs))))

--- a/src/spec_tools/visitor.cljc
+++ b/src/spec_tools/visitor.cljc
@@ -23,6 +23,12 @@
 (defn extract-form [spec]
   (if (seq? spec) spec (s/form spec)))
 
+(defn unwrap
+  "Unwrap [x] to x. Asserts that coll has exactly one element."
+  [coll]
+  {:pre [(= 1 (count coll))]}
+  (first coll))
+
 (defn- spec-dispatch
   [spec accept options]
   (cond
@@ -36,7 +42,7 @@
     (set? spec) ::set
     (seq? spec) (normalize-symbol (first (strip-fn-if-needed spec)))
     (symbol? spec) (normalize-symbol spec)
-    :else (form/resolve-form spec)))
+    :else (normalize-symbol (form/resolve-form spec))))
 
 (defmulti visit-spec spec-dispatch :default ::default)
 

--- a/src/spec_tools/visitor.cljc
+++ b/src/spec_tools/visitor.cljc
@@ -55,7 +55,8 @@
 (defn visit
   "Walk a spec definition. Takes 2-3 arguments, the spec and the accept
   function, and optionally a options map, and returns the result of
-  calling the accept function.
+  calling the accept function. Options map can be used to pass in context-
+  spesific information to to sub-visits & accepts.
 
   The accept function is called with 4 arguments: the dispatch term for the
   spec (see below), the spec itself, vector with the results of

--- a/src/spec_tools/visitor.cljc
+++ b/src/spec_tools/visitor.cljc
@@ -56,7 +56,7 @@
   "Walk a spec definition. Takes 2-3 arguments, the spec and the accept
   function, and optionally a options map, and returns the result of
   calling the accept function. Options map can be used to pass in context-
-  spesific information to to sub-visits & accepts.
+  specific information to to sub-visits & accepts.
 
   The accept function is called with 4 arguments: the dispatch term for the
   spec (see below), the spec itself, vector with the results of

--- a/src/spec_tools/visitor.cljc
+++ b/src/spec_tools/visitor.cljc
@@ -23,6 +23,12 @@
 (defn extract-form [spec]
   (if (seq? spec) spec (s/form spec)))
 
+(defn namespaced-name [key]
+  (if key
+    (if-let [nn (namespace key)]
+      (str nn "/" (name key))
+      (name key))))
+
 (defn unwrap
   "Unwrap [x] to x. Asserts that coll has exactly one element."
   [coll]

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -33,11 +33,22 @@
 (s/def ::regex (s/or :int int? :string string?))
 (s/def ::spec (s/spec int?))
 
-(deftest get-spec-test
+(deftest spec-name-test
+  (is (= nil (st/spec-name #{1 2})))
   (is (= :kikka (st/spec-name :kikka)))
   (is (= ::regex (st/spec-name (s/get-spec ::regex))))
   (is (= ::spec (st/spec-name (s/get-spec ::spec))))
-  (is (= ::overridden (st/spec-name (st/spec {:spec (s/get-spec ::spec) :name ::overridden})))))
+  (is (= ::overridden (st/spec-name
+                        (st/spec
+                          {:spec (s/get-spec ::spec)
+                           :name ::overridden})))))
+
+(deftest spec-description-test
+  (is (= nil (st/spec-description #{1 2})))
+  (is (= "description" (st/spec-description
+                         (st/spec
+                           {:spec (s/get-spec ::spec)
+                            :description "description"})))))
 
 (deftest spec?-test
   (testing "spec"

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -30,6 +30,15 @@
   (is (= spec/boolean? (st/coerce-spec spec/boolean?)))
   (is (thrown? #?(:clj Exception, :cljs js/Error) (st/coerce-spec ::INVALID))))
 
+(s/def ::regex (s/or :int int? :string string?))
+(s/def ::spec (s/spec int?))
+
+(deftest get-spec-test
+  (is (= :kikka (st/spec-name :kikka)))
+  (is (= ::regex (st/spec-name (s/get-spec ::regex))))
+  (is (= ::spec (st/spec-name (s/get-spec ::spec))))
+  (is (= ::overridden (st/spec-name (st/spec {:spec (s/get-spec ::spec) :name ::overridden})))))
+
 (deftest spec?-test
   (testing "spec"
     (let [spec (s/spec integer?)]

--- a/test/cljc/spec_tools/json_schema_test.cljc
+++ b/test/cljc/spec_tools/json_schema_test.cljc
@@ -11,6 +11,7 @@
 (s/def ::integer integer?)
 (s/def ::string string?)
 (s/def ::set #{1 2 3})
+(s/def ::keys (s/keys :req-un [::integer]))
 
 (deftest simple-spec-test
   (testing "primitive predicates"
@@ -36,6 +37,11 @@
            {:type "object"
             :properties {"integer" {:type "integer"} "string" {:type "string"}}
             :required ["integer"]}))
+    (is (= (jsc/transform ::keys)
+           {:type "object",
+            :properties {"integer" {:type "integer"}},
+            :required ["integer"],
+            :title "spec-tools.json-schema-test/keys"}))
     (is (= (jsc/transform (s/or :int integer? :string string?))
            {:anyOf [{:type "integer"} {:type "string"}]}))
     (is (= (jsc/transform (s/and integer? pos?))

--- a/test/cljc/spec_tools/json_schema_test.cljc
+++ b/test/cljc/spec_tools/json_schema_test.cljc
@@ -4,9 +4,9 @@
             [spec-tools.core :as st]
             [spec-tools.data-spec :as ds]
             [com.gfredericks.test.chuck.clojure-test :refer [checking]]
+            [spec-tools.json-schema :as jsc]
     #?(:clj
-            [scjsv.core :as scjsv])
-            [spec-tools.json-schema :as jsc]))
+            [scjsv.core :as scjsv])))
 
 (s/def ::integer integer?)
 (s/def ::string string?)
@@ -73,7 +73,7 @@
             :items {:anyOf [{:type "integer"} {:type "string"}]}}))
     ;; & is broken (http://dev.clojure.org/jira/browse/CLJ-2152)
     (is (= (jsc/transform (s/tuple integer? string?))
-           {:type "array" :items [{:type "integer"} {:type "string"}] :minItems 2}))
+           {:type "array" :items [{:type "integer"} {:type "string"}] :minItems 2 :maxItems 2}))
     ;; keys* is broken (http://dev.clojure.org/jira/browse/CLJ-2152)
     (is (= (jsc/transform (s/map-of string? clojure.core/integer?))
            {:type "object" :additionalProperties {:type "integer"}}))

--- a/test/cljc/spec_tools/visitor_test.cljc
+++ b/test/cljc/spec_tools/visitor_test.cljc
@@ -9,10 +9,11 @@
 (s/def ::int integer?)
 (s/def ::map (s/keys :req [::str] :opt [::int]))
 
-(defn collect [dispatch _ children] `[~dispatch ~@children])
+(defn collect [dispatch _ children _] `[~dispatch ~@children])
 
 (deftest test-visit
   (is (= (visitor/visit #{1 2 3} collect) [:spec-tools.visitor/set 1 3 2]))
+  (is (= (visitor/visit int? collect) ['clojure.core/int?]))
   (is (= (visitor/visit ::map collect)
          '[clojure.spec.alpha/keys [clojure.core/string?] [clojure.core/integer?]])))
 
@@ -25,7 +26,7 @@
 ; https://gist.github.com/shafeeq/c2ded8e71579a26e44c2191536e01c0d
 (deftest recursive-visit
   (let [specs (atom {})
-        collect (fn [_ spec _]
+        collect (fn [_ spec _ _]
                   (if-let [registered (s/get-spec spec)]
                     (swap! specs assoc spec (s/form registered))
                     @specs))]

--- a/test/cljc/spec_tools/visitor_test.cljc
+++ b/test/cljc/spec_tools/visitor_test.cljc
@@ -17,6 +17,7 @@
 (defn collect [dispatch _ children _] `[~dispatch ~@children])
 
 (deftest test-visit
+  (is (= (visitor/visit #(pos? %) collect) [::s/unknown]))
   (is (= (visitor/visit #{1 2 3} collect) [:spec-tools.visitor/set 1 3 2]))
   (is (= (visitor/visit int? collect) ['clojure.core/int?]))
   (is (= (visitor/visit ::map collect)

--- a/test/cljc/spec_tools/visitor_test.cljc
+++ b/test/cljc/spec_tools/visitor_test.cljc
@@ -5,6 +5,11 @@
             [spec-tools.data-spec :as ds]
             [spec-tools.visitor :as visitor]))
 
+(deftest namespaced-name-test
+  (is (= nil (visitor/namespaced-name nil)))
+  (is (= "kikka" (visitor/namespaced-name :kikka)))
+  (is (= "spec-tools.visitor-test/kikka" (visitor/namespaced-name ::kikka))))
+
 (s/def ::str string?)
 (s/def ::int integer?)
 (s/def ::map (s/keys :req [::str] :opt [::int]))


### PR DESCRIPTION
* **BREAKING**: More configurable Spec Visitor
  * `spec-tools.visitor/visit takes optionally 4th argument, an options-map, passed into all sub-visits & accepts
  * changed the extension multimethod from `visit` to `visit-spec` (to better support static analysis for arity errors)
  * the `accept` function is not 4-arity (was 3-arity), taking the options-map as 4th argument
  * the `spec-tools.json-schema/transform` also has optional 4-arity with the options-map as 4th argument

* visitor (and by so, json-schema generation) supports also direct predicate specs, via form inference:

* added `spec-tools.core/spec-name`, to resolve spec name, like `clojure.spec.alpha/spec-name` but non-private & understands Spec Records.
* added `spec-tools.core/spec-description`, to resolve spec description, understands Spec Records.

* JSON Schema generation set `:title` for Object Schemas based on `st/spec-name`.

```clj
(require '[spec-tools.json-schema :as json-schema])

(json-schema/transform int?)
; {:type "integer", :format "int64"}
```
