### PR TITLE
fixes metosin/compojure-api#334

### DIFF
--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -6,8 +6,8 @@
             [spec-tools.conform :as conform]
             [clojure.spec.alpha :as s]
     #?@(:clj  [
-            [clojure.spec.gen.alpha :as gen]
-            [clojure.edn]]
+               [clojure.spec.gen.alpha :as gen]
+               [clojure.edn]]
         :cljs [[goog.date.UtcDateTime]
                [cljs.reader]
                [clojure.test.check.generators]
@@ -280,6 +280,8 @@
           :xx/yy  any qualified keys can be added (optional)"
   [{:keys [spec type form] :as m}]
   (assert spec "missing spec predicate")
+  (when (qualified-keyword? spec)
+    (assert (s/get-spec spec) (str " Unable to resolve spec: " (:spec m))))
   (let [spec (if (qualified-keyword? spec)
                (s/get-spec spec) spec)
         form (or (if (qualified-keyword? form)

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -74,6 +74,9 @@
                (st/create-spec {:spec integer? :type :long})
                (st/create-spec {:spec integer?, :form `integer?})
                (st/create-spec {:spec integer?, :form `integer?, :type :long}))))
+      (testing "fails"
+        (is (thrown? #?(:clj AssertionError, :cljs js/Error)
+              (st/create-spec {:spec :un-existent/keyword-spec}))))
 
       (testing "::s/name is retained"
         (is (= ::age (::s/name (meta (st/create-spec {:spec ::age}))))))


### PR DESCRIPTION
- assert qualified spec keyword exists
- add tests for spec failure on nonexistent specs

PS: sorry for the indentation changes. Cursive did that automatically and it re-does it whenever I save the file