### PR TITLE
Parse merge specs

### DIFF
--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -273,7 +273,7 @@
                  (form/resolve-form spec)
                  ::s/unknown)
         info (parse/parse-spec form)
-        type (if-not (contains? m :type) (:type info) type)
+        type (if (contains? m :type) type (:type info))
         name (-> spec meta ::s/name)
         record (map->Spec
                  (merge m info {:spec spec :form form, :type type}))]

--- a/src/spec_tools/impl.cljc
+++ b/src/spec_tools/impl.cljc
@@ -133,6 +133,17 @@
   {:pre [(= 1 (count coll))]}
   (first coll))
 
+(defn deep-merge [& values]
+  (cond
+    (every? map? values)
+    (apply merge-with deep-merge values)
+
+    (every? coll? values)
+    (reduce into values)
+
+    :else
+    (last values)))
+
 ;;
 ;; FIXME: using ^:skip-wiki functions from clojure.spec. might break.
 ;;

--- a/src/spec_tools/impl.cljc
+++ b/src/spec_tools/impl.cljc
@@ -25,14 +25,6 @@
     (:name x)
     x))
 
-(defn clojure-core-symbol-or-any [x]
-  (or
-    (if (symbol? x)
-      (if-let [ns (get {"cljs.core" "clojure.core"
-                        "cljs.spec.alpha" "clojure.spec.alpha"} (namespace x))]
-        (symbol ns (name x))))
-    x))
-
 (defn- clj-sym [x]
   (if (var? x)
     (let [^Var v x]

--- a/src/spec_tools/parse.cljc
+++ b/src/spec_tools/parse.cljc
@@ -21,11 +21,11 @@
 
     ;; symbol
     (symbol? x)
-    (parse-form (impl/clojure-core-symbol-or-any x) nil)
+    (parse-form (impl/normalize-symbol x) nil)
 
     ;; a from
     (seq? x)
-    (parse-form (impl/clojure-core-symbol-or-any (first x)) x)
+    (parse-form (impl/normalize-symbol (first x)) x)
 
     ;; a spec
     (s/spec? x)
@@ -121,7 +121,8 @@
 (defmethod parse-form 'clojure.spec.alpha/and [_ form]
   (parse-spec (second form)))
 
-; merge
+(defmethod parse-form 'clojure.spec.alpha/merge [_ form]
+  (apply impl/deep-merge (map parse-spec (rest form))))
 
 (defmethod parse-form 'clojure.spec.alpha/every [_ form]
   (let [{:keys [into]} (apply hash-map (drop 2 form))]
@@ -142,6 +143,9 @@
        :else :vector)}))
 
 (defmethod parse-form 'clojure.spec.alpha/map-of [_ _] {:type :map})
+
+(defmethod parse-form 'spec-tools.core/spec [_ form]
+  (parse-spec (-> form last :spec)))
 
 ; *
 ; +

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -128,7 +128,7 @@
            {:spec (spec-tools.core/spec
                     {:spec double?
                      :type :double})
-            :type nil})
+            :type :double})
 
         (st/spec (fn [x] (> x 10)))
         `(spec-tools.core/spec

--- a/test/cljc/spec_tools/impl_test.cljc
+++ b/test/cljc/spec_tools/impl_test.cljc
@@ -12,3 +12,16 @@
   (is (= false (impl/nilable-spec? nil)))
   (is (= false (impl/nilable-spec? string?)))
   (is (= true (impl/nilable-spec? (s/nilable string?)))))
+
+(deftest deep-merge-test
+  (is (= {:a 2
+          :b [1 2 3 4]
+          :c {:a 2, :b 1}}
+         (impl/deep-merge
+           {:a 1
+            :b [1 2]
+            :c {:a 1}}
+           {:a [1 2]
+            :c {:a 2, :b 1}}
+           {:a 2
+            :b [3 4]}))))

--- a/test/cljc/spec_tools/parse_test.cljc
+++ b/test/cljc/spec_tools/parse_test.cljc
@@ -1,7 +1,8 @@
 (ns spec-tools.parse-test
   (:require [clojure.test :refer [deftest is]]
+            [clojure.spec.alpha :as s]
             [spec-tools.parse :as parse]
-            [clojure.spec.alpha :as s]))
+            [spec-tools.core :as st]))
 
 (s/def ::a string?)
 (s/def ::b string?)
@@ -9,14 +10,30 @@
 (s/def ::d string?)
 (s/def ::e string?)
 
+(s/def ::f string?)
+(s/def ::g string?)
+
 (s/def ::keys (s/keys :opt [::e]
                       :opt-un [::e]
                       :req [::a (or ::b (and ::c ::d))]
                       :req-un [::a (or ::b (and ::c ::d))]))
+
+(s/def ::keys2 (st/spec (s/keys :opt [::f]
+                                :opt-un [::f]
+                                :req [::g]
+                                :req-un [::g])))
+
+(s/def ::merged (s/merge ::keys ::keys2))
 
 (deftest parse-test
   (is (= {:type :map
           :keys #{:a :b :c :d :e ::a ::b ::c ::d ::e}
           :keys/req #{:a :b :c :d ::a ::b ::c ::d}
           :keys/opt #{:e ::e}}
-         (parse/parse-spec ::keys))))
+         (parse/parse-spec ::keys)))
+
+  (is (= {:type :map
+          :keys #{:a :b :c :d :e :f :g ::a ::b ::c ::d ::e ::f ::g}
+          :keys/req #{:a :b :c :d :g ::a ::b ::c ::d ::g}
+          :keys/opt #{:e :f ::e ::f}}
+         (parse/parse-spec ::merged))))


### PR DESCRIPTION
Now we can parse `s/merge` and `st/spec` too.