### PR TITLE
If a `:required` would be empty do not include it

### DIFF
--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -189,12 +189,15 @@
         names-un (map name (concat req-un opt-un))
         names (map impl/qualified-name (concat req opt))
         required (map impl/qualified-name req)
-        required-un (map name req-un)]
+        required-un (map name req-un)
+        all-required (not-empty (concat required required-un))]
     (maybe-with-title
+     (merge
       {:type "object"
-       :properties (zipmap (concat names names-un) children)
-       :required (vec (concat required required-un))}
-      spec)))
+       :properties (zipmap (concat names names-un) children)}
+      (when all-required
+        {:required (vec all-required)}))
+     spec)))
 
 (defmethod accept-spec 'clojure.spec.alpha/or [_ _ children _]
   {:anyOf children})

--- a/test/cljc/spec_tools/json_schema_test.cljc
+++ b/test/cljc/spec_tools/json_schema_test.cljc
@@ -24,6 +24,9 @@
                       :req [::a (or ::b (and ::c ::d))]
                       :req-un [::a (or ::b (and ::c ::d))]))
 
+(s/def ::keys-no-req (s/keys :opt [::e]
+                             :opt-un [::e]))
+
 (deftest simple-spec-test
   (testing "primitive predicates"
     ;; You're intented to call jsc/to-json with a registered spec, but to avoid
@@ -69,6 +72,11 @@
                        "b"
                        "c"
                        "d"]}))
+    (is (= (jsc/transform ::keys-no-req)
+           {:type "object"
+            :title "spec-tools.json-schema-test/keys-no-req"
+            :properties {"spec-tools.json-schema-test/e" {:type "string"}
+                         "e" {:type "string"}}}))
     (is (= (jsc/transform (s/or :int integer? :string string?))
            {:anyOf [{:type "integer"} {:type "string"}]}))
     (is (= (jsc/transform (s/and integer? pos?))


### PR DESCRIPTION
This was/is causing a relatively cryptic Swagger validation error. I was given the advice of removing empty `:required` fields. It worked and so this commit fixes that issue. Includes a test and `lein test` passes.