### PR TITLE
ds/spec map syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,37 @@
 ; true
 ```
 
+* `ds/spec` supports 1-arity version, allowing extra options `:keys-spec` & `:keys-default`.
+
+```clj
+(require '[clojure.spec.alpha :as s])
+(require '[spec-tools.data-spec :as ds])
+
+(s/valid?
+  (ds/spec
+    {:name ::optiona-user
+     :spec {(ds/req :id) int?
+            :age pos-int?
+            :name string?}
+     :keys-default ds/opt})
+  {:id 123})
+; true
+```
+
+* `ds/spec` option `:name` is only required if non-qualified map keys are present.
+
+```clj
+(require '[clojure.spec.alpha :as s])
+(require '[spec-tools.data-spec :as ds])
+
+(s/valid?
+  (ds/spec
+    {:spec [{::alias string?}]})
+  [{::alias "kikka"}
+   {::alias "kukka"}])
+; true
+```
+
 * updated deps:
 
 ```clj

--- a/README.md
+++ b/README.md
@@ -349,10 +349,23 @@ Data Specs offers an alternative, Schema-like data-driven syntax to define simpl
   (dissoc person ::id))
 ```
 
-* to turn a data-spec into a Spec, call `ds/spec` on it, providing a qualified keyword describing the root spec name - used to generate unique names for sub-specs that will be registered.
+* to turn a data-spec into a Spec, call `ds/spec` on it, providing either a options map or a qualified keyword describing the root spec name - used to generate unique names for sub-specs that will be registered. Valid options:
+
+| Key                | Description                                                                       |
+| -------------------|-----------------------------------------------------------------------------------|
+| `:spec`            | The wrapped data-spec.                                                            |
+| `:name`            | Qualified root spec anme - used to generate unique names for sub-specs.           |
+| `:keys-spec`       | Function to wrap not-wrapped keys, e.g. `ds/un` to make keys optional by default. |
+| `:keys-default`    | Function to generate the keys-specs, default `ds/keys-specs`.                     |
 
 ```clj
-;; transform into specs
+;; options-syntax
+(def person-spec
+  (ds/spec
+    {:name ::person
+     :spec person}))
+
+;; legacy syntax
 (def person-spec
   (ds/spec ::person person))
 


### PR DESCRIPTION
+ `keys-spec`
+ `keys-default`

* fixes #98 

Together with (a modified fork of) [strictly-specking](https://github.com/bhauman/strictly-specking) enables figwheel-grade errors with spec-tools:

<img width="702" alt="strictly" src="https://user-images.githubusercontent.com/567532/36220943-1a93c8a0-11c5-11e8-9100-46e17936bd7a.png">
