### PR TITLE
Adds support for JSON Schema "$ref" to jsc/transform

### DIFF
--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -273,7 +273,15 @@
         extra-info (-> data
                        (select-keys [:name :description])
                        (set/rename-keys {:name :title}))]
-    (merge (impl/unwrap children) extra-info json-schema-meta)))
+    (let [{:keys [type items] :as m} (merge (impl/unwrap children)
+                                            extra-info
+                                            json-schema-meta)]
+      (if (and (:items-ref json-schema-meta)
+               (= "array" type))
+        (-> m
+            (assoc :items {"$ref" (:items-ref json-schema-meta)})
+            (dissoc m :items-ref))
+        m))))
 
 (defmethod accept-spec ::default [_ _ _ _]
   {})

--- a/test/cljc/spec_tools/json_schema_test.cljc
+++ b/test/cljc/spec_tools/json_schema_test.cljc
@@ -181,6 +181,18 @@
               :description "it's an int"
               :json-schema/default 42})))))
 
+(deftest json-schema-ref-test
+  (is (= {:type "array"
+          :items {"$ref" "#/definitions/Map"}
+          :title "maps"
+          :description "it's some maps"}
+         (jsc/transform
+          (st/spec
+           {:spec (s/coll-of map?)
+            :name "maps"
+            :description "it's some maps"
+            :json-schema/items-ref "#/definitions/Map"})))))
+
 (deftest deeply-nested-test
   (is (= {:type "array"
           :items {:type "array"


### PR DESCRIPTION
Adds support for JSON Schema references.

Example:

```clj
(ns swagger
  (:require [cheshire.core :as json]
            [clojure.spec.alpha :as s]
            [spec-tools.json-schema :as jsc]
            [spec-tools.swagger.core :as swagger]))

(s/def :foo/id string?)

(s/def :foo/foo (s/keys :req-un [:foo/id]))

(s/def :foo/items (st/spec (s/coll-of :foo/foo)
                  {:json-schema/items-ref "#/definitions/Foo"}))

(s/def :foo/page (st/spec (s/keys :req-un [:foo/items]
                                           :opt-un [:foo/next])
                                   {:description "A page of results"}))

(-> (jsc/transform :foo/page)
    (json/generate-string {:pretty true}))
```

```javascript
{
  “type” : “object”,
  “properties” : {
    “items” : {
      “type” : “array”,
      "items": {“$ref” : “#/definitions/Foo”}
    },
    “next” : {
      “type” : “string”,
      “description” : “Reference to next page of results; use as query parameter to subsequent requests”
    }
  },
  “required” : [ “items” ],
  “description” : “A page of results”
}
```