### PR TITLE
Make Instant conforming ISO8601-compliant in clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,8 @@
           :source-uri "https://github.com/metosin/spec-tools/{version}/{filepath}#L{line}"
           :metadata {:doc/format :markdown}}
 
-  :dependencies [[org.clojure/spec.alpha "0.1.143"]]
+  :dependencies [[org.clojure/spec.alpha "0.1.143"]
+                 [com.fasterxml.jackson.core/jackson-databind "2.9.5"]]
 
   :profiles {:dev {:plugins [[jonase/eastwood "0.2.5"]
                              [lein-tach "1.0.0"]

--- a/src/spec_tools/conform.cljc
+++ b/src/spec_tools/conform.cljc
@@ -5,10 +5,9 @@
                [goog.date.Date]])
             [clojure.set :as set])
   #?(:clj
-     (:import (java.util Calendar Date TimeZone UUID)
-              (javax.xml.bind DatatypeConverter)
-              (java.time LocalDate Instant ZoneOffset)
-              (java.time.format DateTimeFormatter))))
+     (:import (java.util Date UUID)
+              (com.fasterxml.jackson.databind.util StdDateFormat)
+              (java.time Instant))))
 
 ;;
 ;; Strings
@@ -60,17 +59,7 @@
 (defn string->date [_ x]
   (if (string? x)
     (try
-      #?(:clj (try
-                 ;; Try first parsing the "yyyy-mm-dd" format (ISO Date), because
-                 ;; in this case we have to set the offset to UTC, so the date refers
-                 ;; to the current day, and it's not offsetted by the JVM current timezone
-                 (-> x
-                     (LocalDate/parse DateTimeFormatter/ISO_LOCAL_DATE)
-                     (.atStartOfDay)
-                     (.toInstant ZoneOffset/UTC)
-                     (Date/from))
-                 ;; If we cannot match on a date, we try parsing the Istant/DateTime syntax
-                 (catch Exception _ (.getTime (DatatypeConverter/parseDateTime x))))
+      #?(:clj  (.parse (StdDateFormat.) x)
          :cljs (js/Date. (.getTime (goog.date.UtcDateTime.fromIsoString x))))
       (catch #?(:clj  Exception, :cljs js/Error) _ x))
     x))

--- a/test/cljc/spec_tools/conform_test.cljc
+++ b/test/cljc/spec_tools/conform_test.cljc
@@ -32,7 +32,11 @@
 
 (deftest string->date
   (is (= #inst "2014-02-18T18:25:37Z" (conform/string->date _ "2014-02-18T18:25:37Z")))
+  (is (= #inst "2018-04-27T00:00:00Z" (conform/string->date _ "2018-04-27")))
+  (is (= #inst "2018-04-27T05:00:00Z" (conform/string->date _ "2018-04-27T08:00:00+03:00")))
   (is (= #inst "2014-02-18T18:25:37Z" (conform/string->date _ #inst "2014-02-18T18:25:37Z")))
+  (is (= #inst "2018-04-27T00:00:00Z" (conform/string->date _ #inst "2018-04-27")))
+  (is (= #inst "2018-04-27T05:00:00Z" (conform/string->date _ #inst "2018-04-27T08:00:00+03:00")))
   (is (= "abba" (conform/string->date _ "abba"))))
 
 (deftest string->symbol


### PR DESCRIPTION
In practice: 

On a clj repl, the following (the current `string->date` implementation) would throw an exception:
```clojure
 (Date/from (Instant/parse "2018-04-27"))
```

while on a cljs repl (tested on latest `lumo`) the same would return the correct result:
```clojure
cljs.user=> (js/Date. (.getTime (goog.date.UtcDateTime.fromIsoString "2018-04-27")))
#inst "2018-04-27T00:00:00.000-00:00"
```

This PR fixes the mismatches in ISO8601 parsing between the clj and cljs implementation, by making the clj implementation ISO8601-compliant.
So now we cover parsing of things like simple ISO Date format (e.g. `2018-04-27`) and different ways of specifying timezone offsets (i.e. "+01", "+01:00", "Z", etc).

Links about implementation details :
- [Compliant ISO8601 in Java](https://stackoverflow.com/a/2202300)
- [Fixing the idiosyncrasies of the Calendar->Date conversion and JVM own timezone with `java.time`](https://gist.github.com/salomvary/79977bbdb3a9cccadac2#file-datetime-java-L46)
