### PR TITLE
Swagger improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.7.1
 
+* Not setting a Swagger response model doesn't emit empty schema `{}`.
 * updated deps:
 
 ```clj

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.7.1
+# 0.7.1-SNAPSHOT
 
 * Not setting a Swagger response model doesn't emit empty schema `{}`.
 * Spec keys with `swagger` namespace are merged into Swagger schemas, overriding values from `json-schema` namespaced keys:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.7.1
+
+* updated deps:
+
+```clj
+[com.fasterxml.jackson.core/jackson-databind "2.9.6"] is available but we use "2.9.5"
+```
+
 # 0.7.0 (14.5.2018)
 
 * Fix `rational?` mapping for JSON Schema, fixes [#113](https://github.com/metosin/spec-tools/issues/113)
@@ -23,7 +31,6 @@
   (-encoder [this spec value])
   (-decoder [this spec value]))
 ```
-
 
 ### Spec-driven transformations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # 0.7.1
 
 * Not setting a Swagger response model doesn't emit empty schema `{}`.
+* Spec keys with `swagger` namespace are merged into Swagger schemas, overriding values from `json-schema` namespaced keys:
+
+```clj
+(require '[spec-tools.core :as st])
+(require '[spec-tools.swagger.core :as swagger])
+
+(swagger/transform
+  (st/spec
+    {:spec string?
+     :json-schema/default ""
+     :json-schema/example "json-schema-example"
+     :swagger/example "swagger-example"}))
+; {:type "string"
+;  :default ""
+;  :example "swagger-example"}
+```
+
 * updated deps:
 
 ```clj

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The following Spec keys having a special meaning:
 | `:decode/...`      | 2-arity function to transform a value from an external format.              |
 | `:encode/...`      | 2-arity function to transform a value into external format.                 |
 | `:json-schema/...` | Extra data that is merged with unqualifed keys into json-schema             |
+| `:swagger/...`     | Extra data that is merged with unqualifed keys into swagger-schema          |
 
 ### Creating Specs
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/spec-tools "0.7.1"
+(defproject metosin/spec-tools "0.7.1-SNAPSHOT"
   :description "Clojure(Script) tools for clojure.spec"
   :url "https://github.com/metosin/spec-tools"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/spec-tools "0.7.0"
+(defproject metosin/spec-tools "0.7.1"
   :description "Clojure(Script) tools for clojure.spec"
   :url "https://github.com/metosin/spec-tools"
   :license {:name "Eclipse Public License"
@@ -12,7 +12,7 @@
           :metadata {:doc/format :markdown}}
 
   :dependencies [[org.clojure/spec.alpha "0.1.143"]
-                 [com.fasterxml.jackson.core/jackson-databind "2.9.5"]]
+                 [com.fasterxml.jackson.core/jackson-databind "2.9.6"]]
 
   :profiles {:dev {:plugins [[jonase/eastwood "0.2.6"]
                              [lein-tach "1.0.0"]
@@ -23,7 +23,7 @@
                    :jvm-opts ^:replace ["-server"]
                    ;:global-vars {*warn-on-reflection* true}
                    :dependencies [[org.clojure/clojure "1.9.0"]
-                                  [org.clojure/clojurescript "1.9.946"]
+                                  [org.clojure/clojurescript "1.10.329"]
                                   [criterium "0.4.4"]
                                   [prismatic/schema "1.1.9"]
                                   [org.clojure/test.check "0.9.0"]

--- a/src/spec_tools/impl.cljc
+++ b/src/spec_tools/impl.cljc
@@ -138,6 +138,14 @@
     :else
     (last values)))
 
+(defn unlift-keys [data ns-name]
+  (reduce
+    (fn [acc [k v]]
+      (if (= ns-name (namespace k))
+        (assoc acc (keyword (name k)) v)
+        acc))
+    {} data))
+
 ;;
 ;; FIXME: using ^:skip-wiki functions from clojure.spec. might break.
 ;;

--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -263,13 +263,7 @@
 
 (defmethod accept-spec ::visitor/spec [_ spec children _]
   (let [[_ data] (impl/extract-form spec)
-        json-schema-meta (reduce-kv
-                           (fn [acc k v]
-                             (if (= "json-schema" (namespace k))
-                               (assoc acc (keyword (name k)) v)
-                               acc))
-                           {}
-                           (into {} data))
+        json-schema-meta (impl/unlift-keys data "json-schema")
         extra-info (-> data
                        (select-keys [:name :description])
                        (set/rename-keys {:name :title}))]

--- a/src/spec_tools/swagger/core.cljc
+++ b/src/spec_tools/swagger/core.cljc
@@ -107,9 +107,9 @@
    (into
      (or (:responses acc) {})
      (for [[status response] v]
-       [status (-> response
-                   (update :schema transform {:type :schema})
-                   (update :description (fnil identity "")))]))})
+       [status (as-> response $
+                     (if (:schema $) (update $ :schema transform {:type :schema}) $)
+                     (update $ :description (fnil identity "")))]))})
 
 (defmethod expand ::parameters [_ v acc _]
   (let [old (or (:parameters acc) [])
@@ -124,7 +124,8 @@
                             acc)))
                       [[] #{}])
                     (first)
-                    (reverse))]
+                    (reverse)
+                    (vec))]
     {:parameters merged}))
 
 (defn expand-qualified-keywords [x options]

--- a/src/spec_tools/swagger/core.cljc
+++ b/src/spec_tools/swagger/core.cljc
@@ -55,6 +55,11 @@
   (let [k (if (and (= type :parameter) (not= in :body)) :allowEmptyValue :x-nullable)]
     (assoc (impl/unwrap children) k true)))
 
+(defmethod accept-spec ::visitor/spec [dispatch spec children options]
+  (let [[_ data] (impl/extract-form spec)
+        swagger-meta (impl/unlift-keys data "swagger")]
+    (merge (json-schema/accept-spec dispatch spec children options) swagger-meta)))
+
 (defmethod accept-spec ::default [dispatch spec children options]
   (json-schema/accept-spec dispatch spec children options))
 

--- a/test/cljc/spec_tools/impl_test.cljc
+++ b/test/cljc/spec_tools/impl_test.cljc
@@ -25,3 +25,13 @@
             :c {:a 2, :b 1}}
            {:a 2
             :b [3 4]}))))
+
+(deftest unlift-keys-test
+  (is (= {:olut 0.5
+          :sielu true}
+         (impl/unlift-keys
+           {:iso/olut 0.5
+            :iso/sielu true
+            :olipa "kerran"
+            :kikka/kukka "kakka"}
+           "iso"))))

--- a/test/cljc/spec_tools/swagger/core_test.cljc
+++ b/test/cljc/spec_tools/swagger/core_test.cljc
@@ -4,8 +4,8 @@
     [spec-tools.swagger.core :as swagger]
     [clojure.spec.alpha :as s]
     [spec-tools.spec :as spec]
-    #?(:clj
-    [ring.swagger.validator :as v])))
+    #?(:clj [ring.swagger.validator :as v])
+    [spec-tools.core :as st]))
 
 (s/def ::integer integer?)
 (s/def ::string string?)
@@ -134,7 +134,14 @@
    {:type "object", :additionalProperties {:type "integer"}}
 
    (s/nilable string?)
-   {:type "string", :x-nullable true}})
+   {:type "string", :x-nullable true}
+
+   (st/spec
+     {:spec string?
+      :json-schema/default ""
+      :json-schema/example "json-schema-example"
+      :swagger/example "swagger-example"})
+   {:type "string", :default "", :example "swagger-example"}})
 
 (deftest test-expectations
   (doseq [[spec swagger-spec] exceptations]

--- a/test/cljc/spec_tools/swagger/core_test.cljc
+++ b/test/cljc/spec_tools/swagger/core_test.cljc
@@ -251,8 +251,7 @@
                    :required ["id" "name" "address"]
                    :title "spec-tools.swagger.core-test/user"}
                   :description ""}
-             404 {:schema {}
-                  :description "Ohnoes."}
+             404 {:description "Ohnoes."}
              500 {:description "fail"}}}
            (swagger/swagger-spec
              {:responses {404 {:description "fail"}


### PR DESCRIPTION
* Not setting a Swagger response model doesn't emit empty schema `{}`.
* Spec keys with `swagger` namespace are merged into Swagger schemas, overriding values from `json-schema` namespaced keys:

```clj
(require '[spec-tools.core :as st])
(require '[spec-tools.swagger.core :as swagger])

(swagger/transform
  (st/spec
    {:spec string?
     :json-schema/default ""
     :json-schema/example "json-schema-example"
     :swagger/example "swagger-example"}))
; {:type "string"
;  :default ""
;  :example "swagger-example"}
```

* updated deps:

```clj
[com.fasterxml.jackson.core/jackson-databind "2.9.6"] is available but we use "2.9.5"
```