### PR TITLE
Swagger with spec record (cljs support)

### DIFF
--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -215,6 +215,12 @@
        (specize* [s] s)
        (specize* [s _] s)])
 
+  ;; https://dev.clojure.org/jira/browse/CLJS-1297
+  #?@(:cljs
+     [IKVReduce
+      (-kv-reduce [coll f init]
+        (reduce-kv f init (into {} coll)))])
+
   s/Spec
   (conform* [this x]
     (let [transformer *transformer*, encode? *encode?*]

--- a/test/cljc/spec_tools/swagger/core_test.cljc
+++ b/test/cljc/spec_tools/swagger/core_test.cljc
@@ -272,7 +272,7 @@
                           :description "",
                           :required true,
                           :schema {:type "object",
-                                   :title "spec-tools.swagger.core-test/address",
+                                   ;; :title "spec-tools.swagger.core-test/address",
                                    :properties {"street" {:type "string"},
                                                 "city" {:enum [:tre :hki],
                                                         :type "string"

--- a/test/cljc/spec_tools/swagger/core_test.cljc
+++ b/test/cljc/spec_tools/swagger/core_test.cljc
@@ -239,7 +239,59 @@
               ::swagger/parameters
               {:query (s/keys :opt-un [::name ::street ::city])
                :path (s/keys :req [::id])
-               :body ::address}}))))
+               :body ::address}})))
+    (is (= {:parameters [{:in "query"
+                          :name "name2"
+                          :description "this survives the merge"
+                          :type "string"
+                          :required true}
+                         {:in "query"
+                          :name "name"
+                          :description ""
+                          :type "string"
+                          :required false}
+                         {:in "query"
+                          :name "street"
+                          :description ""
+                          :type "string"
+                          :required false}
+                         {:in "query"
+                          :name "city"
+                          :description ""
+                          :type "string"
+                          :required false
+                          :enum [:tre :hki]
+                          :allowEmptyValue true}
+                         {:in "path"
+                          :name "spec-tools.swagger.core-test/id"
+                          :description ""
+                          :type "string"
+                          :required true}
+                         {:in "body",
+                          :name "spec-tools.swagger.core-test/address",
+                          :description "",
+                          :required true,
+                          :schema {:type "object",
+                                   :title "spec-tools.swagger.core-test/address",
+                                   :properties {"street" {:type "string"},
+                                                "city" {:enum [:tre :hki],
+                                                        :type "string"
+                                                        :x-nullable true}},
+                                   :required ["street" "city"]}}]}
+           (swagger/swagger-spec
+             {:parameters [{:in "query"
+                            :name "name"
+                            :description "this will be overridden"
+                            :required false}
+                           {:in "query"
+                            :name "name2"
+                            :description "this survives the merge"
+                            :type "string"
+                            :required true}]
+              ::swagger/parameters
+              {:query (st/create-spec {:spec (s/keys :opt-un [::name ::street ::city])})
+               :path (st/create-spec {:spec (s/keys :req [::id])})
+               :body (st/create-spec {:spec ::address})}}))))
 
   (testing "::responses"
     (is (= {:responses


### PR DESCRIPTION
Hi. I was playing with reitit and Macchiato (https://github.com/macchiato-framework/macchiato-core/issues/7) but I am not sure how to generate spec. I've tried to follow guide for ring (https://metosin.github.io/reitit/ring/swagger.html).

It looks like reitit is converting given spec in `:parameters` into spec records and then I get following error in cljs:
```
#object[Error Error: No protocol method IKVReduce.-kv-reduce defined for type : [object Object]]
```

it comes from this function: https://github.com/metosin/spec-tools/blob/cb4b44845ae379e2b0f0f2e145aa1570fe00513b/src/spec_tools/swagger/core.cljc#L136

It seems to sort of work for clj, the result is just a bit different with spec records in the test (added test is just copy-paste of the test above, just with converted spec to spec records). Spec record is missing `:title` key in `body.schema`.