### PR TITLE
Coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # UNRELEASED
 
 * Fix [fishy gen* call in your Spec protocol](https://github.com/metosin/spec-tools/issues/136).
-* New `st/coerce` function to coerce a value using form parsing and spec transformers. Can only walk over simple specs (`s/or`, `s/and`, `s/coll-of`, `s/map-of`, `s/tuple`, `s/keys` and `s/nilable`) without any wrapping of specs. Inspired by [spec-coerce](https://github.com/wilkerlucio/spec-coerce).
+* New `st/coerce` function to coerce a value using form parsing and spec transformers. Can only walk over simple specs, and doesn't require any wrapping of specs. Inspired by [spec-coerce](https://github.com/wilkerlucio/spec-coerce).
 
 ```clj
 (deftest coercion-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@
              (st/coerce spec value st/json-transformer))))))
 ```
 
-* `st/decode` first tries to use `st/coerce`, then the old conforming-based approach
+* `st/decode` first tries to use `st/coerce`, fallbacking to conforming-based approach
 * **BREAKING**: enchanced parsing results from `spec-tools.parse/parse-spec`:
   * all parse result keys have been qualified:
     * `:keys` => `::parse/keys`

--- a/README.md
+++ b/README.md
@@ -36,14 +36,16 @@ The following Spec keys having a special meaning:
 | `:name`            | Name of the spec. Maps to `title` in JSON Schema.                           |
 | `:description`     | Description of the spec. Maps to `description` in JSON Schema.              |
 | `:gen`             | Generator function for the Spec (set via `s/with-gen`)                      |
-| `:keys`            | Set of all map keys that the spec defines. Extracted from `s/keys` Specs.   |
-| `:keys/req`        | Set of required map keys that the spec defines. Extracted from `s/keys` Specs.|
-| `:keys/opt`        | Set of optional map keys that the spec defines. Extracted from `s/keys` Specs.|
+| `::parse/keys`     | Set of all map keys that the spec defines. Extracted from `s/keys` Specs.   |
+| `::parse/keys-req` | Set of required map keys that the spec defines. Extracted from `s/keys` Specs.|
+| `::parse/keys-opt` | Set of optional map keys that the spec defines. Extracted from `s/keys` Specs.|
 | `:reason`          | Value is added to `s/explain-data` problems under key `:reason`             |
 | `:decode/...`      | 2-arity function to transform a value from an external format.              |
 | `:encode/...`      | 2-arity function to transform a value into external format.                 |
 | `:json-schema/...` | Extra data that is merged with unqualifed keys into json-schema             |
 | `:swagger/...`     | Extra data that is merged with unqualifed keys into swagger-schema          |
+
+There are also some extra read-only keys from spec parsing, these all are namespaced with `::parse` (`spec-tools.parse`).
 
 ### Creating Specs
 

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -169,14 +169,18 @@
            (throw (ex-info (str "Spec conform error: " data) data))))))))
 
 (defn coerce
+  "Coerces the value using a [[Transformer]]. Returns original value for
+  those parts of the value that can't be trasformed."
   ([spec value transformer]
    (coerce spec value transformer nil))
   ([spec value transformer options]
    (-coerce (into-spec spec) value transformer options)))
 
 (defn decode
-  "Transforms and validates a value (using a [[Transformer]]) from external
-  format into a value defined by the spec. On error, returns `::s/invalid`."
+  "Decodes a value using a [[Transformer]] from external format to a value
+  defined by the spec. First, calls [[coerce]] and returns the value if it's
+  valid - otherwise, calls [[conform]] & [[unform]]. Returns `::s/invalid`
+  if the value can't be decoded to conform the spec."
   ([spec value]
    (decode spec value nil))
   ([spec value transformer]

--- a/src/spec_tools/parse.cljc
+++ b/src/spec_tools/parse.cljc
@@ -1,8 +1,12 @@
 (ns spec-tools.parse
   (:require [spec-tools.impl :as impl]
-            [clojure.spec.alpha :as s]))
+            [clojure.spec.alpha :as s]
+            [spec-tools.form :as form]))
 
 (declare parse-form)
+
+(defn type-dispatch-value [type]
+  ((if (sequential? type) first identity) type))
 
 (defn parse-spec
   "Parses info out of a spec. Spec can be passed as a name, Spec or a form.
@@ -31,6 +35,10 @@
     (s/spec? x)
     (recur (s/form x))
 
+    ;; a predicate
+    (ifn? x)
+    (parse-form (form/resolve-form x) nil)
+
     ;; default
     :else (parse-form x nil)))
 
@@ -51,6 +59,9 @@
     :date
     :ratio
     :map
+    :map-of
+    :and
+    :or
     :set
     :vector})
 
@@ -61,74 +72,81 @@
       (->> (filter symbol?))
       set))
 
-(defmethod parse-form 'clojure.core/any? [_ _])
-(defmethod parse-form 'clojure.core/some? [_ _])
-(defmethod parse-form 'clojure.core/number? [_ _] {:type :double})
-(defmethod parse-form 'clojure.core/integer? [_ _] {:type :long})
-(defmethod parse-form 'clojure.core/int? [_ _] {:type :long})
-(defmethod parse-form 'clojure.core/pos-int? [_ _] {:type :long})
-(defmethod parse-form 'clojure.core/neg-int? [_ _] {:type :long})
-(defmethod parse-form 'clojure.core/nat-int? [_ _] {:type :long})
-(defmethod parse-form 'clojure.core/float? [_ _] {:type :double})
-(defmethod parse-form 'clojure.core/double? [_ _] {:type :double})
-(defmethod parse-form 'clojure.core/boolean? [_ _] {:type :boolean})
-(defmethod parse-form 'clojure.core/string? [_ _] {:type :string})
-(defmethod parse-form 'clojure.core/ident? [_ _] {:type :keyword})
-(defmethod parse-form 'clojure.core/simple-ident? [_ _] {:type :keyword})
-(defmethod parse-form 'clojure.core/qualified-ident? [_ _] {:type :keyword})
-(defmethod parse-form 'clojure.core/keyword? [_ _] {:type :keyword})
-(defmethod parse-form 'clojure.core/simple-keyword? [_ _] {:type :keyword})
-(defmethod parse-form 'clojure.core/qualified-keyword? [_ _] {:type :keyword})
-(defmethod parse-form 'clojure.core/symbol? [_ _] {:type :symbol})
-(defmethod parse-form 'clojure.core/simple-symbol? [_ _] {:type :symbol})
-(defmethod parse-form 'clojure.core/qualified-symbol? [_ _] {:type :symbol})
-(defmethod parse-form 'clojure.core/uuid? [_ _] {:type :uuid})
-#?(:clj (defmethod parse-form 'clojure.core/uri? [_ _] {:type :uri}))
-#?(:clj (defmethod parse-form 'clojure.core/decimal? [_ _] {:type :bigdec}))
-(defmethod parse-form 'clojure.core/inst? [_ _] {:type :date})
-(defmethod parse-form 'clojure.core/seqable? [_ _])
-(defmethod parse-form 'clojure.core/indexed? [_ _])
-(defmethod parse-form 'clojure.core/map? [_ _])
-(defmethod parse-form 'clojure.core/vector? [_ _])
-(defmethod parse-form 'clojure.core/list? [_ _])
-(defmethod parse-form 'clojure.core/seq? [_ _])
-(defmethod parse-form 'clojure.core/char? [_ _])
-(defmethod parse-form 'clojure.core/set? [_ _])
-(defmethod parse-form 'clojure.core/nil? [_ _])
-(defmethod parse-form 'clojure.core/false? [_ _] {:type :boolean})
-(defmethod parse-form 'clojure.core/true? [_ _] {:type :boolean})
-(defmethod parse-form 'clojure.core/zero? [_ _] {:type :long})
-#?(:clj (defmethod parse-form 'clojure.core/rational? [_ _] {:type :long}))
-(defmethod parse-form 'clojure.core/coll? [_ _])
-(defmethod parse-form 'clojure.core/empty? [_ _])
-(defmethod parse-form 'clojure.core/associative? [_ _] {:type nil})
-(defmethod parse-form 'clojure.core/sequential? [_ _] {:type nil})
-#?(:clj (defmethod parse-form 'clojure.core/ratio? [_ _] {:type :ratio}))
-#?(:clj (defmethod parse-form 'clojure.core/bytes? [_ _]))
+(defmethod parse-form 'clojure.core/any?               [_ _] {:spec any?})
+(defmethod parse-form 'clojure.core/some?              [_ _] {:spec some?})
+(defmethod parse-form 'clojure.core/number?            [_ _] {:spec number?, :type :double})
+(defmethod parse-form 'clojure.core/integer?           [_ _] {:spec integer?, :type :long})
+(defmethod parse-form 'clojure.core/int?               [_ _] {:spec int?, :type :long})
+(defmethod parse-form 'clojure.core/pos-int?           [_ _] {:spec pos-int?, :type :long})
+(defmethod parse-form 'clojure.core/neg-int?           [_ _] {:spec neg-int?, :type :long})
+(defmethod parse-form 'clojure.core/nat-int?           [_ _] {:spec nat-int?, :type :long})
+(defmethod parse-form 'clojure.core/float?             [_ _] {:spec float?, :type :double})
+(defmethod parse-form 'clojure.core/double?            [_ _] {:spec double?, :type :double})
+(defmethod parse-form 'clojure.core/boolean?           [_ _] {:spec boolean?, :type :boolean})
+(defmethod parse-form 'clojure.core/string?            [_ _] {:spec string?, :type :string})
+(defmethod parse-form 'clojure.core/ident?             [_ _] {:spec ident? :type :keyword})
+(defmethod parse-form 'clojure.core/simple-ident?      [_ _] {:spec simple-ident?, :type :keyword})
+(defmethod parse-form 'clojure.core/qualified-ident?   [_ _] {:spec qualified-ident?, :type :keyword})
+(defmethod parse-form 'clojure.core/keyword?           [_ _] {:spec keyword?, :type :keyword})
+(defmethod parse-form 'clojure.core/simple-keyword?    [_ _] {:spec simple-keyword?, :type :keyword})
+(defmethod parse-form 'clojure.core/qualified-keyword? [_ _] {:spec qualified-keyword? :type :keyword})
+(defmethod parse-form 'clojure.core/symbol?            [_ _] {:spec symbol?, :type :symbol})
+(defmethod parse-form 'clojure.core/simple-symbol?     [_ _] {:spec simple-symbol?, :type :symbol})
+(defmethod parse-form 'clojure.core/qualified-symbol?  [_ _] {:spec qualified-symbol?, :type :symbol})
+(defmethod parse-form 'clojure.core/uuid?              [_ _] {:spec uuid?, :type :uuid})
+#?(:clj (defmethod parse-form 'clojure.core/uri?       [_ _] {:spec uri?, :type :uri}))
+#?(:clj (defmethod parse-form 'clojure.core/decimal?   [_ _] {:spec decimal?, :type :bigdec}))
+(defmethod parse-form 'clojure.core/inst?              [_ _] {:spec inst?, :type :date})
+(defmethod parse-form 'clojure.core/seqable?           [_ _] {:spec seqable?})
+(defmethod parse-form 'clojure.core/indexed?           [_ _] {:spec indexed?})
+(defmethod parse-form 'clojure.core/map?               [_ _] {:spec map?})
+(defmethod parse-form 'clojure.core/vector?            [_ _] {:spec vector?})
+(defmethod parse-form 'clojure.core/list?              [_ _] {:spec list?})
+(defmethod parse-form 'clojure.core/seq?               [_ _] {:spec seq?})
+(defmethod parse-form 'clojure.core/char?              [_ _] {:spec char?})
+(defmethod parse-form 'clojure.core/set?               [_ _] {:spec set?})
+(defmethod parse-form 'clojure.core/nil?               [_ _] {:spec nil?})
+(defmethod parse-form 'clojure.core/false?             [_ _] {:spec false?, :type :boolean})
+(defmethod parse-form 'clojure.core/true?              [_ _] {:spec true?, :type :boolean})
+(defmethod parse-form 'clojure.core/zero?              [_ _] {:spec zero?, :type :long})
+#?(:clj (defmethod parse-form 'clojure.core/rational?  [_ _] {:spec rational?, :type :long}))
+(defmethod parse-form 'clojure.core/coll?              [_ _] {:spec coll?})
+(defmethod parse-form 'clojure.core/empty?             [_ _] {:spec empty?})
+(defmethod parse-form 'clojure.core/associative?       [_ _] {:spec associative?, :type nil})
+(defmethod parse-form 'clojure.core/sequential?        [_ _] {:spec sequential?})
+#?(:clj (defmethod parse-form 'clojure.core/ratio?     [_ _] {:spec ratio?, :type :ratio}))
+#?(:clj (defmethod parse-form 'clojure.core/bytes?     [_ _] {:spec bytes?}))
 
 (defmethod parse-form :clojure.spec.alpha/unknown [_ _])
 
 (defmethod parse-form 'clojure.spec.alpha/keys [_ form]
   (let [{:keys [req opt req-un opt-un key->spec]} (impl/parse-keys form)]
     (cond-> {:type :map
-             :keys (set (concat req opt req-un opt-un))
-             :keys/key->spec key->spec}
-            (or req req-un) (assoc :keys/req (set (concat req req-un)))
-            (or opt opt-un) (assoc :keys/opt (set (concat opt opt-un))))))
+             ::key->spec key->spec
+             ::keys (set (concat req opt req-un opt-un))}
+            (or req req-un) (assoc ::keys-req (set (concat req req-un)))
+            (or opt opt-un) (assoc ::keys-opt (set (concat opt opt-un))))))
 
-(defmethod parse-form 'clojure.spec.alpha/or [_ _])
+(defmethod parse-form 'clojure.spec.alpha/or [_ form]
+  (let [specs (mapv (comp parse-spec second) (partition 2 (rest form)))]
+    {:type [:or (->> specs (map :type) (distinct) (keep identity) (vec))]
+     ::items specs}))
 
 (defmethod parse-form 'clojure.spec.alpha/and [_ form]
-  (parse-spec (second form)))
+  (let [specs (mapv parse-spec (rest form))
+        types (->> specs (map :type) (distinct) (keep identity) (vec))]
+    {:type (if (> (count types) 1) [:and types] (first types))
+     ::items specs}))
 
 (defmethod parse-form 'clojure.spec.alpha/merge [_ form]
   (apply impl/deep-merge (map parse-spec (rest form))))
 
 (defmethod parse-form 'clojure.spec.alpha/every [_ form]
   (let [{:keys [into]} (apply hash-map (drop 2 form))]
-    {:type
+    {::item (parse-spec (second form))
+     :type
      (cond
-       (map? into) :map
+       (map? into) :map-of
        (set? into) :set
        :else :vector)}))
 
@@ -136,13 +154,17 @@
 
 (defmethod parse-form 'clojure.spec.alpha/coll-of [_ form]
   (let [{:keys [into]} (apply hash-map (drop 2 form))]
-    {:type
+    {::item (parse-spec (second form))
+     :type
      (cond
-       (map? into) :map
+       (map? into) :map-of
        (set? into) :set
        :else :vector)}))
 
-(defmethod parse-form 'clojure.spec.alpha/map-of [_ _] {:type :map})
+(defmethod parse-form 'clojure.spec.alpha/map-of [_ [_ k v]]
+  {:type :map-of
+   ::key (parse-spec k)
+   ::value (parse-spec v)})
 
 (defmethod parse-form 'spec-tools.core/spec [_ form]
   (parse-spec (-> form last :spec)))
@@ -153,9 +175,23 @@
 ; alt
 ; cat
 ; &
-; tuple
 ; keys*
-; nilable
+
+(defmethod parse-form 'clojure.spec.alpha/tuple [_ [_ & values :as form]]
+  (let [specs (mapv parse-spec values)
+        types (mapv :type specs)]
+    {:type :vector
+     ::size (count values)
+     ::items types}))
+
+(defmethod parse-form 'clojure.spec.alpha/nilable [_ form]
+  (assoc (parse-spec (second form)) ::nilable? true))
 
 (defmethod parse-form 'spec-tools.core/merge [_ form]
   (apply impl/deep-merge (map parse-spec (rest form))))
+
+;;
+;; publics
+;;
+
+(def anything (parse-spec any?))

--- a/src/spec_tools/parse.cljc
+++ b/src/spec_tools/parse.cljc
@@ -42,7 +42,7 @@
     ;; default
     :else (parse-form x nil)))
 
-(defmulti parse-form (fn [dispath _] dispath) :default ::default)
+(defmulti parse-form (fn [dispatch _] dispatch) :default ::default)
 
 (defmethod parse-form ::default [_ _] {:type nil})
 
@@ -177,7 +177,7 @@
 ; &
 ; keys*
 
-(defmethod parse-form 'clojure.spec.alpha/tuple [_ [_ & values :as form]]
+(defmethod parse-form 'clojure.spec.alpha/tuple [_ [_ & values]]
   (let [specs (mapv parse-spec values)
         types (mapv :type specs)]
     {:type :vector
@@ -189,9 +189,3 @@
 
 (defmethod parse-form 'spec-tools.core/merge [_ form]
   (apply impl/deep-merge (map parse-spec (rest form))))
-
-;;
-;; publics
-;;
-
-(def anything (parse-spec any?))

--- a/src/spec_tools/parse.cljc
+++ b/src/spec_tools/parse.cljc
@@ -109,9 +109,10 @@
 (defmethod parse-form :clojure.spec.alpha/unknown [_ _])
 
 (defmethod parse-form 'clojure.spec.alpha/keys [_ form]
-  (let [{:keys [req opt req-un opt-un]} (impl/parse-keys form)]
+  (let [{:keys [req opt req-un opt-un key->spec]} (impl/parse-keys form)]
     (cond-> {:type :map
-             :keys (set (concat req opt req-un opt-un))}
+             :keys (set (concat req opt req-un opt-un))
+             :keys/key->spec key->spec}
             (or req req-un) (assoc :keys/req (set (concat req req-un)))
             (or opt opt-un) (assoc :keys/opt (set (concat opt opt-un))))))
 

--- a/src/spec_tools/transform.cljc
+++ b/src/spec_tools/transform.cljc
@@ -4,6 +4,7 @@
     #?@(:cljs [[goog.date.UtcDateTime]
                [goog.date.Date]])
             [clojure.set :as set]
+            [spec-tools.parse :as parse]
             [clojure.string :as str])
   #?(:clj
      (:import (java.util Date UUID)
@@ -105,7 +106,7 @@
 ;; Maps
 ;;
 
-(defn strip-extra-keys [{:keys [keys]} x]
+(defn strip-extra-keys [{:keys [::parse/keys]} x]
   (if (and keys (map? x))
     (select-keys x keys)
     x))

--- a/src/spec_tools/visitor.cljc
+++ b/src/spec_tools/visitor.cljc
@@ -86,7 +86,7 @@
         pred (second form)
         {:keys [type]} (parse/parse-spec form)
         dispatch (case type
-                   :map ::map-of
+                   :map-of ::map-of
                    :set ::set-of
                    :vector ::vector-of)]
     (accept dispatch spec [(visit pred accept options)] options)))

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -6,6 +6,7 @@
             [spec-tools.spec :as spec]
             [spec-tools.parse :as info]
             [spec-tools.form :as form]
+            [spec-tools.parse :as parse]
             [#?(:clj  clojure.spec.gen.alpha
                 :cljs cljs.spec.gen.alpha) :as gen]
             [spec-tools.transform :as stt]))
@@ -270,8 +271,7 @@
      :encode/string #(-> %2 name str/upper-case)}))
 (s/def ::my-spec-map (s/keys :req [::my-spec]))
 
-(s/def ::my-type
-  (st/spec keyword?))
+(s/def ::my-type (st/spec keyword?))
 (s/def ::my-type-map (s/keys :req [::my-type]))
 
 (deftest encode-decode-test
@@ -327,6 +327,58 @@
     (testing "encode and decode also unform"
       (is (= "1" (st/encode ::regex 1 st/string-transformer)))
       (is (= 1 (st/decode ::regex "1" st/string-transformer))))))
+
+(s/def ::c1 int?)
+(s/def ::c2 keyword?)
+
+(deftest coercion-test
+  (testing "predicates"
+    (is (= 1 (st/coerce int? "1" st/string-transformer)))
+    (is (= "1" (st/coerce int? "1" st/json-transformer)))
+    (is (= :user/kikka (st/coerce keyword? "user/kikka" st/string-transformer))))
+  (testing "s/and"
+    (is (= 1 (st/coerce (s/and int? keyword?) "1" st/string-transformer)))
+    (is (= :1 (st/coerce (s/and keyword? int?) "1" st/string-transformer))))
+  (testing "s/or"
+    (is (= 1 (st/coerce (s/or :int int? :keyword keyword?) "1" st/string-transformer)))
+    (is (= :1 (st/coerce (s/or :keyword keyword? :int int?) "1" st/string-transformer))))
+  (testing "s/coll-of"
+    (is (= #{1 2 3} (st/coerce (s/coll-of int? :into #{}) ["1" 2 "3"] st/string-transformer)))
+    (is (= #{"1" 2 "3"} (st/coerce (s/coll-of int? :into #{}) ["1" 2 "3"] st/json-transformer)))
+    (is (= [:1 2 :3] (st/coerce (s/coll-of keyword?) ["1" 2 "3"] st/string-transformer)))
+    (is (= ::invalid (st/coerce (s/coll-of keyword?) ::invalid st/string-transformer))))
+  (testing "s/keys"
+    (is (= {:c1 1, ::c2 :kikka} (st/coerce (s/keys :req-un [::c1]) {:c1 "1", ::c2 "kikka"} st/string-transformer)))
+    (is (= {:c1 1, ::c2 :kikka} (st/coerce (s/keys :req-un [(and ::c1 ::c2)]) {:c1 "1", ::c2 "kikka"} st/string-transformer)))
+    (is (= {:c1 "1", ::c2 :kikka} (st/coerce (s/keys :req-un [::c1]) {:c1 "1", ::c2 "kikka"} st/json-transformer)))
+    (is (= ::invalid (st/coerce (s/keys :req-un [::c1]) ::invalid st/json-transformer))))
+  (testing "s/map-of"
+    (is (= {1 :abba, 2 :jabba} (st/coerce (s/map-of int? keyword?) {"1" "abba", "2" "jabba"} st/string-transformer)))
+    (is (= {"1" :abba, "2" :jabba} (st/coerce (s/map-of int? keyword?) {"1" "abba", "2" "jabba"} st/json-transformer)))
+    (is (= ::invalid (st/coerce (s/map-of int? keyword?) ::invalid st/json-transformer))))
+  (testing "s/nillable"
+    (is (= 1 (st/coerce (s/nilable int?) "1" st/string-transformer)))
+    (is (= nil (st/coerce (s/nilable int?) nil st/string-transformer))))
+  (testing "s/every"
+    (is (= [1] (st/coerce (s/every int?) ["1"] st/string-transformer))))
+  (testing "composed"
+    (let [spec (s/nilable
+                 (s/nilable
+                   (s/map-of
+                     keyword?
+                     (s/or :keys (s/keys :req-un [::c1])
+                           :ks (s/coll-of (s/and int?) :into #{})))))
+          value {"keys" {:c1 "1" ::c2 "kikka"}
+                 "keys2" {:c1 true}
+                 "ints" [1 "1" "invalid" "3"]}]
+      (is (= {:keys {:c1 1 ::c2 :kikka}
+              :keys2 {:c1 true}
+              :ints #{1 "invalid" 3}}
+             (st/coerce spec value st/string-transformer)))
+      (is (= {:keys {:c1 "1" ::c2 :kikka}
+              :keys2 {:c1 true}
+              :ints #{1 "1" "invalid" "3"}}
+             (st/coerce spec value st/json-transformer))))))
 
 (deftest conform!-test
   (testing "suceess"
@@ -473,9 +525,14 @@
 
   (testing "all keys types are extracted"
     (is (= {:type :map
-            :keys #{::age :lat ::truth :uuid}
-            :keys/req #{::age :lat}
-            :keys/opt #{::truth :uuid}}
+            ::parse/key->spec {:lat ::lat
+                               ::age ::age
+                               ::truth ::truth
+                               :uuid ::uuid}
+
+            ::parse/keys #{::age :lat ::truth :uuid}
+            ::parse/keys-req #{::age :lat}
+            ::parse/keys-opt #{::truth :uuid}}
 
            ;; named spec
            (info/parse-spec
@@ -500,8 +557,12 @@
 
   (testing "ands and ors are flattened"
     (is (= {:type :map
-            :keys #{::age ::lat ::uuid}
-            :keys/req #{::age ::lat ::uuid}}
+            ::parse/key->spec {::age ::age
+                               ::lat ::lat
+                               ::uuid ::uuid}
+
+            ::parse/keys #{::age ::lat ::uuid}
+            ::parse/keys-req #{::age ::lat ::uuid}}
            (info/parse-spec
              (s/keys
                :req [(or ::age (and ::uuid ::lat))]))))))
@@ -593,3 +654,4 @@
       (testing "has a working describe"
         (is (= (s/describe ::core-map)
                (:spec (second (s/describe ::map)))))))))
+

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -654,4 +654,3 @@
       (testing "has a working describe"
         (is (= (s/describe ::core-map)
                (:spec (second (s/describe ::map)))))))))
-

--- a/test/cljc/spec_tools/data_spec_test.cljc
+++ b/test/cljc/spec_tools/data_spec_test.cljc
@@ -3,6 +3,7 @@
             [clojure.spec.alpha :as s]
             [spec-tools.data-spec :as ds]
             [spec-tools.core :as st]
+            [spec-tools.parse :as parse]
             [spec-tools.spec :as spec])
   #?(:clj
      (:import clojure.lang.ExceptionInfo)))
@@ -285,8 +286,9 @@
       (is (= `(spec-tools.core/spec
                 {:spec (clojure.spec.alpha/keys :req [::i])
                  :type :map
-                 :keys #{::i}
-                 :keys/req #{::i}})
+                 ::parse/key->spec {::i ::i}
+                 ::parse/keys #{::i}
+                 ::parse/keys-req #{::i}})
              (s/form spec1)
              (s/form spec2)))))
 

--- a/test/cljc/spec_tools/parse_test.cljc
+++ b/test/cljc/spec_tools/parse_test.cljc
@@ -28,12 +28,36 @@
 (deftest parse-test
   (is (= {:type :map
           :keys #{:a :b :c :d :e ::a ::b ::c ::d ::e}
+          :keys/key->spec {:a :spec-tools.parse-test/a
+                           :b :spec-tools.parse-test/b
+                           :c :spec-tools.parse-test/c
+                           :d :spec-tools.parse-test/d
+                           :e :spec-tools.parse-test/e
+                           :spec-tools.parse-test/a :spec-tools.parse-test/a
+                           :spec-tools.parse-test/b :spec-tools.parse-test/b
+                           :spec-tools.parse-test/c :spec-tools.parse-test/c
+                           :spec-tools.parse-test/d :spec-tools.parse-test/d
+                           :spec-tools.parse-test/e :spec-tools.parse-test/e}
           :keys/req #{:a :b :c :d ::a ::b ::c ::d}
           :keys/opt #{:e ::e}}
          (parse/parse-spec ::keys)))
 
   (is (= {:type :map
           :keys #{:a :b :c :d :e :f :g ::a ::b ::c ::d ::e ::f ::g}
+          :keys/key->spec {:a :spec-tools.parse-test/a
+                           :b :spec-tools.parse-test/b
+                           :c :spec-tools.parse-test/c
+                           :d :spec-tools.parse-test/d
+                           :e :spec-tools.parse-test/e
+                           :f :spec-tools.parse-test/f
+                           :g :spec-tools.parse-test/g
+                           :spec-tools.parse-test/a :spec-tools.parse-test/a
+                           :spec-tools.parse-test/b :spec-tools.parse-test/b
+                           :spec-tools.parse-test/c :spec-tools.parse-test/c
+                           :spec-tools.parse-test/d :spec-tools.parse-test/d
+                           :spec-tools.parse-test/e :spec-tools.parse-test/e
+                           :spec-tools.parse-test/f :spec-tools.parse-test/f
+                           :spec-tools.parse-test/g :spec-tools.parse-test/g}
           :keys/req #{:a :b :c :d :g ::a ::b ::c ::d ::g}
           :keys/opt #{:e :f ::e ::f}}
          (parse/parse-spec ::merged))))

--- a/test/cljc/spec_tools/parse_test.cljc
+++ b/test/cljc/spec_tools/parse_test.cljc
@@ -1,5 +1,5 @@
 (ns spec-tools.parse-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest testing is]]
             [clojure.spec.alpha :as s]
             [spec-tools.parse :as parse]
             [spec-tools.core :as st]))

--- a/test/cljc/spec_tools/parse_test.cljc
+++ b/test/cljc/spec_tools/parse_test.cljc
@@ -1,5 +1,5 @@
 (ns spec-tools.parse-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer :all]
             [clojure.spec.alpha :as s]
             [spec-tools.parse :as parse]
             [spec-tools.core :as st]))
@@ -26,38 +26,84 @@
 (s/def ::merged (s/merge ::keys ::keys2))
 
 (deftest parse-test
-  (is (= {:type :map
-          :keys #{:a :b :c :d :e ::a ::b ::c ::d ::e}
-          :keys/key->spec {:a :spec-tools.parse-test/a
-                           :b :spec-tools.parse-test/b
-                           :c :spec-tools.parse-test/c
-                           :d :spec-tools.parse-test/d
-                           :e :spec-tools.parse-test/e
-                           :spec-tools.parse-test/a :spec-tools.parse-test/a
-                           :spec-tools.parse-test/b :spec-tools.parse-test/b
-                           :spec-tools.parse-test/c :spec-tools.parse-test/c
-                           :spec-tools.parse-test/d :spec-tools.parse-test/d
-                           :spec-tools.parse-test/e :spec-tools.parse-test/e}
-          :keys/req #{:a :b :c :d ::a ::b ::c ::d}
-          :keys/opt #{:e ::e}}
-         (parse/parse-spec ::keys)))
+  (testing "predicate"
+    (is (= {:spec double?, :type :double}
+           (parse/parse-spec 'clojure.core/double?)
+           (parse/parse-spec double?))))
+  (testing "s/nilable"
+    (is (= {:spec int?
+            :type :long,
+            ::parse/nilable? true}
+           (parse/parse-spec (s/nilable (s/nilable int?))))))
+  (testing "s/or"
+    (is (= {::parse/items [{:spec int?, :type :long} {:spec keyword?, :type :keyword}]
+            :type [:or [:long :keyword]]}
+           (parse/parse-spec (s/or :int int? :keyword keyword?)))))
+  (testing "s/and"
+    (is (= {::parse/items [{:spec int?, :type :long} {:spec keyword?, :type :keyword}]
+            :type [:and [:long :keyword]]}
+           (parse/parse-spec (s/and int? keyword?)))))
+  (testing "s/keys"
+    (is (= {:type :map
+            ::parse/keys #{:a :b :c :d :e ::a ::b ::c ::d ::e}
+            ::parse/keys-req #{:a :b :c :d ::a ::b ::c ::d}
+            ::parse/keys-opt #{:e ::e}
+            ::parse/key->spec {:a ::a
+                               :b ::b
+                               :c ::c
+                               :d ::d
+                               :e ::e
+                               ::a ::a
+                               ::b ::b
+                               ::c ::c
+                               ::d ::d
+                               ::e ::e}}
+           (parse/parse-spec ::keys)))
 
-  (is (= {:type :map
-          :keys #{:a :b :c :d :e :f :g ::a ::b ::c ::d ::e ::f ::g}
-          :keys/key->spec {:a :spec-tools.parse-test/a
-                           :b :spec-tools.parse-test/b
-                           :c :spec-tools.parse-test/c
-                           :d :spec-tools.parse-test/d
-                           :e :spec-tools.parse-test/e
-                           :f :spec-tools.parse-test/f
-                           :g :spec-tools.parse-test/g
-                           :spec-tools.parse-test/a :spec-tools.parse-test/a
-                           :spec-tools.parse-test/b :spec-tools.parse-test/b
-                           :spec-tools.parse-test/c :spec-tools.parse-test/c
-                           :spec-tools.parse-test/d :spec-tools.parse-test/d
-                           :spec-tools.parse-test/e :spec-tools.parse-test/e
-                           :spec-tools.parse-test/f :spec-tools.parse-test/f
-                           :spec-tools.parse-test/g :spec-tools.parse-test/g}
-          :keys/req #{:a :b :c :d :g ::a ::b ::c ::d ::g}
-          :keys/opt #{:e :f ::e ::f}}
-         (parse/parse-spec ::merged))))
+    (is (= {:type :map
+            ::parse/keys #{:a :b :c :d :e :f :g ::a ::b ::c ::d ::e ::f ::g}
+            ::parse/keys-req #{:a :b :c :d :g ::a ::b ::c ::d ::g}
+            ::parse/keys-opt #{:e :f ::e ::f}
+            ::parse/key->spec {:a ::a
+                               :b ::b
+                               :c ::c
+                               :d ::d
+                               :e ::e
+                               :f ::f
+                               :g ::g
+                               ::a ::a
+                               ::b ::b
+                               ::c ::c
+                               ::d ::d
+                               ::e ::e
+                               ::f ::f
+                               ::g ::g}}
+           (parse/parse-spec ::merged))))
+  (testing "s/merge"
+    (is (= {:type :map
+            ::parse/keys #{:a :b}
+            ::parse/keys-req #{:a :b}
+            ::parse/key->spec {:a ::a, :b ::b}}
+           (parse/parse-spec (s/merge (s/keys :req-un [::a]) (s/keys :req-un [::b]))))))
+  (testing "s/every"
+    (is (= {::parse/item {:spec int?, :type :long}
+            :type :vector}
+           (parse/parse-spec (s/every int?)))))
+  (testing "s/coll-of"
+    (is (= {::parse/item {:spec int?, :type :long}
+            :type :vector}
+           (parse/parse-spec (s/coll-of int?))))
+    (is (= {::parse/item {:spec int?, :type :long}
+            :type :set}
+           (parse/parse-spec (s/coll-of int? :into #{}))))
+    (is (= {::parse/item {::parse/items [:long :keyword]
+                          ::parse/size 2
+                          :type :vector}
+            :type :map-of}
+           (parse/parse-spec (s/coll-of (s/tuple int? keyword?) :into {})))))
+  (testing "s/merge"
+    (is (= {:type :map
+            ::parse/keys #{:a :b}
+            ::parse/keys-req #{:a :b}
+            ::parse/key->spec {:a ::a, :b ::b}}
+           (parse/parse-spec (st/merge (s/keys :req-un [::a]) (s/keys :req-un [::b])))))))


### PR DESCRIPTION
FIxes #65.

* New `st/coerce` function to coerce a value using form parsing and spec transformers. Can only walk over simple specs, and doesn't require any wrapping of specs. Inspired by [spec-coerce](https://github.com/wilkerlucio/spec-coerce).

```clj
(deftest coercion-test
  (testing "predicates"
    (is (= 1 (st/coerce int? "1" st/string-transformer)))
    (is (= "1" (st/coerce int? "1" st/json-transformer)))
    (is (= :user/kikka (st/coerce keyword? "user/kikka" st/string-transformer))))
  (testing "s/and"
    (is (= 1 (st/coerce (s/and int? keyword?) "1" st/string-transformer)))
    (is (= :1 (st/coerce (s/and keyword? int?) "1" st/string-transformer))))
  (testing "s/or"
    (is (= 1 (st/coerce (s/or :int int? :keyword keyword?) "1" st/string-transformer)))
    (is (= :1 (st/coerce (s/or :keyword keyword? :int int?) "1" st/string-transformer))))
  (testing "s/coll-of"
    (is (= #{1 2 3} (st/coerce (s/coll-of int? :into #{}) ["1" 2 "3"] st/string-transformer)))
    (is (= #{"1" 2 "3"} (st/coerce (s/coll-of int? :into #{}) ["1" 2 "3"] st/json-transformer)))
    (is (= [:1 2 :3] (st/coerce (s/coll-of keyword?) ["1" 2 "3"] st/string-transformer)))
    (is (= ::invalid (st/coerce (s/coll-of keyword?) ::invalid st/string-transformer))))
  (testing "s/keys"
    (is (= {:c1 1, ::c2 :kikka} (st/coerce (s/keys :req-un [::c1]) {:c1 "1", ::c2 "kikka"} st/string-transformer)))
    (is (= {:c1 1, ::c2 :kikka} (st/coerce (s/keys :req-un [(and ::c1 ::c2)]) {:c1 "1", ::c2 "kikka"} st/string-transformer)))
    (is (= {:c1 "1", ::c2 :kikka} (st/coerce (s/keys :req-un [::c1]) {:c1 "1", ::c2 "kikka"} st/json-transformer)))
    (is (= ::invalid (st/coerce (s/keys :req-un [::c1]) ::invalid st/json-transformer))))
  (testing "s/map-of"
    (is (= {1 :abba, 2 :jabba} (st/coerce (s/map-of int? keyword?) {"1" "abba", "2" "jabba"} st/string-transformer)))
    (is (= {"1" :abba, "2" :jabba} (st/coerce (s/map-of int? keyword?) {"1" "abba", "2" "jabba"} st/json-transformer)))
    (is (= ::invalid (st/coerce (s/map-of int? keyword?) ::invalid st/json-transformer))))
  (testing "s/nillable"
    (is (= 1 (st/coerce (s/nilable int?) "1" st/string-transformer)))
    (is (= nil (st/coerce (s/nilable int?) nil st/string-transformer))))
  (testing "s/every"
    (is (= [1] (st/coerce (s/every int?) ["1"] st/string-transformer))))
  (testing "composed"
    (let [spec (s/nilable
                 (s/nilable
                   (s/map-of
                     keyword?
                     (s/or :keys (s/keys :req-un [::c1])
                           :ks (s/coll-of (s/and int?) :into #{})))))
          value {"keys" {:c1 "1" ::c2 "kikka"}
                 "keys2" {:c1 true}
                 "ints" [1 "1" "invalid" "3"]}]
      (is (= {:keys {:c1 1 ::c2 :kikka}
              :keys2 {:c1 true}
              :ints #{1 "invalid" 3}}
             (st/coerce spec value st/string-transformer)))
      (is (= {:keys {:c1 "1" ::c2 :kikka}
              :keys2 {:c1 true}
              :ints #{1 "1" "invalid" "3"}}
             (st/coerce spec value st/json-transformer))))))
```

* `st/decode` first tries to use `st/coerce`, then the old conforming-based approach
* **BREAKING**: enchanced parsing results from `spec-tools.parse/parse-spec`:
  * all parse result keys have been qualified:
    * `:keys` => `::parse/keys`
    * `:keys/req` => `::parse/keys-req`
    * `:keys/opt` => `::parse/keys-opt`
  * new parser keys `::parse/items`, `::parse/item`, `::parse/key` and `::parse/value`
  * `s/and` and `s/or` are parsed into composite types:
  
```clj
(testing "s/or"
  (is (= {::parse/items [{:spec int?, :type :long} {:spec keyword?, :type :keyword}]
          :type [:or [:long :keyword]]}
         (parse/parse-spec (s/or :int int? :keyword keyword?)))))
(testing "s/and"
  (is (= {::parse/items [{:spec int?, :type :long} {:spec keyword?, :type :keyword}]
          :type [:and [:long :keyword]]}
         (parse/parse-spec (s/and int? keyword?)))))
```