### PR TITLE
Candidate fix for encoding with data-spec/or

### DIFF
--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -282,6 +282,9 @@
         "Can't invoke spec with a non-function predicate: " spec)
       {:spec spec})))
 
+(defn- leaf? [spec]
+  (:leaf? (into-spec spec)))
+
 (defrecord Spec [spec form type]
   #?@(:clj [s/Specize
             (specize* [s] s)
@@ -312,7 +315,7 @@
               ;; recur
               (let [conformed (s/conform spec transformed)]
                 ;; it's ok if encode transforms the value into invalid
-                (or (and encode? (s/invalid? conformed) transformed) conformed))))
+                (or (and encode? (s/invalid? conformed) (leaf? this) transformed) conformed))))
         (s/conform spec x))))
 
   (unform* [_ x]
@@ -433,7 +436,7 @@
         type (if (contains? m :type) type (:type info))
         name (-> spec meta ::s/name)
         record (map->Spec
-                 (clojure.core/merge m info {:spec spec :form form, :type type}))]
+                 (clojure.core/merge m info {:spec spec :form form :type type :leaf? (parse/leaf-type? type)}))]
     (cond-> record name (with-meta {::s/name name}))))
 
 #?(:clj

--- a/src/spec_tools/parse.cljc
+++ b/src/spec_tools/parse.cljc
@@ -4,12 +4,16 @@
             [spec-tools.form :as form]))
 
 (declare parse-form)
+(declare non-leaf-types)
 
 (defn type-dispatch-value [type]
   ((if (sequential? type) first identity) type))
 
 (defn collection-type? [type]
   (contains? #{:map :map-of :set :vector} type))
+
+(defn leaf-type? [type]
+  (not (contains? (non-leaf-types) type)))
 
 (defn parse-spec
   "Parses info out of a spec. Spec can be passed as a name, Spec or a form.
@@ -48,6 +52,9 @@
 (defmulti parse-form (fn [dispatch _] dispatch) :default ::default)
 
 (defmethod parse-form ::default [_ _] {:type nil})
+
+(defn- non-leaf-types []
+  #{:map :map-of :and :or :set :vector})
 
 (defn types []
   #{:long

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -121,34 +121,41 @@
         (st/spec integer?)
         `(spec-tools.core/spec
            {:spec integer?
-            :type :long})
+            :type :long
+            :leaf? true})
 
         (st/spec #{pos? neg?})
         `(spec-tools.core/spec
            {:spec #{neg? pos?}
-            :type nil})
+            :type nil
+            :leaf? true})
 
         (st/spec ::string)
         `(spec-tools.core/spec
            {:spec string?
-            :type :string})
+            :type :string
+            :leaf? true})
 
         (st/spec ::lat)
         `(spec-tools.core/spec
            {:spec (spec-tools.core/spec
-                    {:spec double?
-                     :type :double})
-            :type :double})
+                   {:spec double?
+                    :type :double
+                    :leaf? true})
+            :type :double
+            :leaf? true})
 
         (st/spec (fn [x] (> x 10)))
         `(spec-tools.core/spec
            {:spec (clojure.core/fn [~'x] (> ~'x 10))
-            :type nil})
+            :type nil
+            :leaf? true})
 
         (st/spec #(> % 10))
         `(spec-tools.core/spec
            {:spec (clojure.core/fn [~'%] (> ~'% 10))
-            :type nil})))
+            :type nil
+            :leaf? true})))
 
     (testing "wrapped predicate work as a predicate"
       (is (true? (my-integer? 1)))
@@ -175,8 +182,9 @@
         (is (= ['spec-tools.core/spec
                 {:spec #?(:clj  'clojure.core/integer?
                           :cljs 'cljs.core/integer?)
-                 :type :long}] (s/form my-integer?)))
-        (is (= ['spec {:spec 'integer? :type :long}] (s/describe my-integer?))))
+                 :type :long
+                 :leaf? true}] (s/form my-integer?)))
+        (is (= ['spec {:spec 'integer? :type :long :leaf? true}] (s/describe my-integer?))))
 
       (testing "type resolution"
         (is (= (st/spec integer?)
@@ -184,7 +192,7 @@
 
       (testing "serialization"
         (let [spec (st/spec {:spec integer? :description "cool", :type ::integer})]
-          (is (= `(st/spec {:spec integer? :description "cool", :type ::integer})
+          (is (= `(st/spec {:spec integer? :description "cool", :type ::integer :leaf? true})
                  (s/form spec)
                  (st/deserialize (st/serialize spec))))))
 


### PR DESCRIPTION
This is a candidate fix for #146.

Introduces a new key `:leaf?` on Spec records, which is defined on Spec creation to be false if the Spec `:type` is any of `:map :map-of :and :or :set :vector`, and true otherwise.

The function `core/leaf?` is used inside `*conform` to ensure that `::s/invalid` is returned to Clojure spec when the result of conform is invalid, for non-leaf specs. This ensures that Clojure spec can continue to try subsequent forms of an `or` spec.

Includes an additional test to check encoding for both forms of an or spec.