### PR TITLE
Remove unnecessary require of clojure.test.check.generators

### DIFF
--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -11,7 +11,6 @@
                        [clojure.edn]]
                 :cljs [[goog.date.UtcDateTime]
                        [cljs.reader]
-                       [clojure.test.check.generators]
                        [cljs.spec.gen.alpha :as gen]]))
   (:import
     #?@(:clj


### PR DESCRIPTION
This causes an unannounced dependency on test.check. I don't think that this require is needed – using `cljs.spec.gen.alpha` should be enough.

If this require *is* needed, then we should add test.check as a dependency.