### PR TITLE
Deserialization of Untrusted Data: upgrade jackson-databind version to 2.9.8

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
           :metadata {:doc/format :markdown}}
 
   :dependencies [[org.clojure/spec.alpha "0.2.176"]
-                 [com.fasterxml.jackson.core/jackson-databind "2.9.7"]]
+                 [com.fasterxml.jackson.core/jackson-databind "2.9.8"]]
 
   :profiles {:dev {:plugins [[jonase/eastwood "0.2.6"]
                              [lein-tach "1.0.0"]


### PR DESCRIPTION
com.fasterxml.jackson.core:jackson-databind is a library which contains the general-purpose data-binding functionality and tree-model for Jackson Data Processor.
Affected versions of this package are vulnerable to Deserialization of Untrusted Data. An attacker could perform a Remote Code Execution attacks due to not blocking the axis2-transport-jms class from polymorphic deserialization.

Remediation
Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.9.8 or higher.

more details

https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72883