### PR TITLE
Support coercion of tuples

### DIFF
--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -240,6 +240,12 @@
     (->> value (map (fn [v] (accept item v options))) (into (empty value)))
     value))
 
+(defmethod walk :tuple [{:keys [::parse/items]} value accept options]
+  (let [pairs (map vector value items)]
+    (map (fn [[v item]]
+           (accept item v options))
+         pairs)))
+
 (defmethod walk :set [{:keys [::parse/item]} value accept options]
   (if (or (set? value) (sequential? value))
     (->> value (map (fn [v] (accept item v options))) (set))

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -241,10 +241,14 @@
     value))
 
 (defmethod walk :tuple [{:keys [::parse/items]} value accept options]
-  (let [pairs (map vector value items)]
-    (map (fn [[v item]]
-           (accept item v options))
-         pairs)))
+  (if (and (sequential? value)
+           (= (count value)
+              (count items)))
+    (let [pairs (map vector value items)]
+     (map (fn [[v item]]
+            (accept item v options))
+          pairs))
+    value))
 
 (defmethod walk :set [{:keys [::parse/item]} value accept options]
   (if (or (set? value) (sequential? value))

--- a/src/spec_tools/parse.cljc
+++ b/src/spec_tools/parse.cljc
@@ -10,7 +10,7 @@
   ((if (sequential? type) first identity) type))
 
 (defn collection-type? [type]
-  (contains? #{:map :map-of :set :vector} type))
+  (contains? #{:map :map-of :set :vector :tuple} type))
 
 (defn leaf-type? [type]
   (not (contains? (non-leaf-types) type)))
@@ -54,7 +54,7 @@
 (defmethod parse-form ::default [_ _] {:type nil})
 
 (defn- non-leaf-types []
-  #{:map :map-of :and :or :set :vector})
+  #{:map :map-of :and :or :set :tuple :vector})
 
 (defn types []
   #{:long
@@ -73,6 +73,7 @@
     :and
     :or
     :set
+    :tuple
     :vector})
 
 (defn type-symbols []
@@ -189,10 +190,10 @@
 
 (defmethod parse-form 'clojure.spec.alpha/tuple [_ [_ & values]]
   (let [specs (mapv parse-spec values)
-        types (mapv :type specs)]
-    {:type :vector
+        types (->> specs (map :type) (distinct) (keep identity) (vec))]
+    {:type [:tuple types]
      ::size (count values)
-     ::items types}))
+     ::items specs}))
 
 (defmethod parse-form 'clojure.spec.alpha/nilable [_ form]
   (assoc (parse-spec (second form)) ::nilable? true))

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -372,7 +372,9 @@
   (testing "s/tuple"
     (is (= [1] (st/coerce (s/tuple int?) ["1"] st/string-transformer)))
     (is (= [1 :kikka] (st/coerce (s/tuple int? keyword?) ["1" "kikka"] st/string-transformer)))
-    (is (= [:kikka 1] (st/coerce (s/tuple keyword? int?) ["kikka" "1"] st/string-transformer))))
+    (is (= [:kikka 1] (st/coerce (s/tuple keyword? int?) ["kikka" "1"] st/string-transformer)))
+    (is (= "1" (st/coerce (s/tuple keyword? int?) "1" st/string-transformer)))
+    (is (= ["kikka" "1" "2"] (st/coerce (s/tuple keyword? int?) ["kikka" "1" "2"] st/string-transformer))))
   (testing "composed"
     (let [spec (s/nilable
                  (s/nilable

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -369,6 +369,10 @@
     (is (= nil (st/coerce (s/nilable int?) nil st/string-transformer))))
   (testing "s/every"
     (is (= [1] (st/coerce (s/every int?) ["1"] st/string-transformer))))
+  (testing "s/tuple"
+    (is (= [1] (st/coerce (s/tuple int?) ["1"] st/string-transformer)))
+    (is (= [1 :kikka] (st/coerce (s/tuple int? keyword?) ["1" "kikka"] st/string-transformer)))
+    (is (= [:kikka 1] (st/coerce (s/tuple keyword? int?) ["kikka" "1"] st/string-transformer))))
   (testing "composed"
     (let [spec (s/nilable
                  (s/nilable

--- a/test/cljc/spec_tools/parse_test.cljc
+++ b/test/cljc/spec_tools/parse_test.cljc
@@ -96,9 +96,10 @@
     (is (= {::parse/item {:spec int?, :type :long}
             :type :set}
            (parse/parse-spec (s/coll-of int? :into #{}))))
-    (is (= {::parse/item {::parse/items [:long :keyword]
+    (is (= {::parse/item {::parse/items [{:spec int?, :type :long}
+                                         {:spec keyword?,:type :keyword}]
                           ::parse/size 2
-                          :type :vector}
+                          :type [:tuple [:long :keyword]]}
             :type :map-of}
            (parse/parse-spec (s/coll-of (s/tuple int? keyword?) :into {})))))
   (testing "s/merge"


### PR DESCRIPTION
Adds a new type `:tuple` and implements the corresponding parse-form and walk multimethods.

Applies each spec to the corresponding element in the tuple.

e.g.
```
(coerce (s/tuple keyword? symbol?) ["kw" "function"] string-transformer)
=> (:kw function)
```