### PR TITLE
Fix s/and parsing

### DIFF
--- a/src/spec_tools/parse.cljc
+++ b/src/spec_tools/parse.cljc
@@ -138,15 +138,18 @@
             (or opt opt-un) (assoc ::keys-opt (set (concat opt opt-un))))))
 
 (defmethod parse-form 'clojure.spec.alpha/or [_ form]
-  (let [specs (mapv (comp parse-spec second) (partition 2 (rest form)))]
-    {:type [:or (->> specs (map :type) (distinct) (keep identity) (vec))]
+  (let [specs (->> (mapv (comp parse-spec second) (partition 2 (rest form)))
+                   (filter :type))]
+    {:type [:or (->> specs (map :type) (distinct) (vec))]
      ::items specs}))
 
 (defmethod parse-form 'clojure.spec.alpha/and [_ form]
-  (let [specs (mapv parse-spec (rest form))
-        types (->> specs (map :type) (distinct) (keep identity) (vec))]
-    {:type (if (> (count types) 1) [:and types] (first types))
-     ::items specs}))
+  (let [specs (->> (mapv parse-spec (rest form))
+                   (filter :type))]
+    (if (> (count specs) 1)
+      {:type [:and (->> specs (map :type) (distinct) (vec))]
+       ::items specs}
+      (first specs))))
 
 (defmethod parse-form 'clojure.spec.alpha/merge [_ form]
   (apply impl/deep-merge (map parse-spec (rest form))))

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -346,7 +346,9 @@
     (is (= :user/kikka (st/coerce keyword? "user/kikka" st/string-transformer))))
   (testing "s/and"
     (is (= 1 (st/coerce (s/and int? keyword?) "1" st/string-transformer)))
-    (is (= :1 (st/coerce (s/and keyword? int?) "1" st/string-transformer))))
+    (is (= :1 (st/coerce (s/and keyword? int?) "1" st/string-transformer)))
+    (is (= [1] (st/coerce (s/and (s/coll-of int?)) ["1"] st/string-transformer)))
+    (is (= [1] (st/coerce (s/and (s/coll-of int?) (comp boolean not-empty)) ["1"] st/string-transformer))))
   (testing "s/or"
     (is (= 1 (st/coerce (s/or :int int? :keyword keyword?) "1" st/string-transformer)))
     (is (= :1 (st/coerce (s/or :keyword keyword? :int int?) "1" st/string-transformer))))


### PR DESCRIPTION
s/and parsing used to have very strange (and broken) behavior for cases where we know only one type. Both of the added tests were failed before.