### PR TITLE
Use first type from composite types with conform on transformations

### DIFF
--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -356,6 +356,12 @@
 (defn- leaf? [spec]
   (:leaf? (into-spec spec)))
 
+(defn- decompose-spec-type [spec]
+  (let [type (:type spec)]
+    (if (sequential? type)
+      (update spec :type (comp first second))
+      spec)))
+
 (defrecord Spec [spec form type]
   #?@(:clj [s/Specize
             (specize* [s] s)
@@ -380,7 +386,7 @@
   (conform* [this x]
     (let [transformer *transformer*, encode? *encode?*]
       ;; if there is a transformer present
-      (if-let [transform (if transformer ((if encode? -encoder -decoder) transformer this x))]
+      (if-let [transform (if transformer ((if encode? -encoder -decoder) transformer (decompose-spec-type this) x))]
         ;; let's transform it
         (let [transformed (transform this x)]
           ;; short-circuit on ::s/invalid

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -356,7 +356,13 @@
 (defn- leaf? [spec]
   (:leaf? (into-spec spec)))
 
-(defn- decompose-spec-type [spec]
+(defn- decompose-spec-type 
+  "Dynamic conforming can't walk over composite specs like s/and & s/or.
+  So, we'll use the first type. Examples:
+
+     `[:and [:int :string]]` -> `:int`
+     `[:or [:string :keyword]]` -> `:string`"
+  [spec]
   (let [type (:type spec)]
     (if (sequential? type)
       (update spec :type (comp first second))

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -440,7 +440,7 @@
         (is (= {coerced coerced} (st/coerce spec {value value} transformer)))
 
         (s/map-of keyword? keyword?) :kikka :kikka
-        (s/map-of symbol? symbol?)  :kikka 'kikka
+        (s/map-of symbol? symbol?) :kikka 'kikka
         (s/map-of int? int?) :1 1
         (s/map-of double? double?) :1.0 1.0
         (s/map-of boolean? boolean?) :true true
@@ -763,3 +763,11 @@
            :response/user
            {:data {:id "41", :type "user", :attributes {:name "string"}}}
            st/string-transformer))))
+
+(deftest issue-123
+  (testing "s/conform can transform composite types"
+    (let [spec (s/double-in :min 0 :NaN? false :infinite? false)]
+      (is (= 114.0
+             (st/decode spec "114.0" st/string-transformer)
+             (st/conform spec "114.0" st/string-transformer)
+             (st/coerce spec "114.0" st/string-transformer))))))


### PR DESCRIPTION
Old impl took the first type from composite types on `conform` when doing transformations. Let's do that again.