### PR TITLE
Make data-specs visitable, fixes #123

### DIFF
--- a/src/spec_tools/visitor.cljc
+++ b/src/spec_tools/visitor.cljc
@@ -4,7 +4,8 @@
             [spec-tools.core :as st]
             [spec-tools.parse :as parse]
             [spec-tools.impl :as impl]
-            [spec-tools.form :as form]))
+            [spec-tools.form :as form]
+            [spec-tools.data-spec :as ds]))
 
 (defn- spec-dispatch
   [spec accept options]
@@ -141,6 +142,11 @@
 (defmethod visit-spec 'spec-tools.core/spec [spec accept options]
   (let [[_ {inner-spec :spec}] (impl/extract-form spec)]
     (accept ::spec spec [(visit inner-spec accept options)] options)))
+
+(defmethod visit-spec 'spec-tools.data-spec/spec [spec accept options]
+  (let [[_ data] (impl/extract-form spec)
+        inner-spec (ds/spec (eval data))] ;; data -> code
+    (visit inner-spec accept options)))
 
 (defmethod visit-spec ::default [spec accept options]
   (accept (spec-dispatch spec accept options) spec nil options))

--- a/test/cljc/spec_tools/visitor_test.cljc
+++ b/test/cljc/spec_tools/visitor_test.cljc
@@ -73,3 +73,13 @@
                    (map s/get-spec)
                    (remove keyword?)
                    (every? st/spec?))))))))
+
+(deftest merged-data-specs-test
+  (is (= #{:required/str :optional/str}
+         (->> (visitor/visit
+                (st/merge
+                  (ds/spec {:spec {:required/str string?}})
+                  (ds/spec {:spec {:optional/str string?}}))
+                (visitor/spec-collector))
+              (keys)
+              (set)))))


### PR DESCRIPTION
Old impl took the first type from composite types on `conform` when doing transformations. Let's do that again.