### PR TITLE
adding coercion for bigdecimal in clojure

### DIFF
--- a/src/spec_tools/transform.cljc
+++ b/src/spec_tools/transform.cljc
@@ -71,12 +71,13 @@
       :else x)
     x))
 
-(defn string->decimal [_ x]
-  (if (string? x)
-    (try
-      #?(:clj  (BigDecimal. x))
-      (catch #?(:clj Exception) _ x))
-    x))
+#?(:clj
+   (defn string->decimal [_ x]
+     (if (string? x)
+       (try
+         #?(:clj  (BigDecimal. x))
+         (catch #?(:clj Exception) _ x))
+       x)))
 
 (defn string->uri [_ x]
   (if (string? x)
@@ -213,16 +214,16 @@
 ;;
 
 (def json-type-encoders
-  {:keyword keyword->string
-   :symbol any->string
-   :uuid any->string
-   :uri any->string
-   :bigdec any->string
-   :date date->string
-   :map any->any
-   :set any->any
-   :vector any->any
-   #?@(:clj [:ratio number->double])})
+   {:keyword keyword->string
+    :symbol any->string
+    :uuid any->string
+    :uri any->string
+    :bigdec any->string
+    :date date->string
+    :map any->any
+    :set any->any
+    :vector any->any
+    #?@(:clj [:ratio number->double])})
 
 (def string-type-encoders
   (merge

--- a/src/spec_tools/transform.cljc
+++ b/src/spec_tools/transform.cljc
@@ -71,6 +71,13 @@
       :else x)
     x))
 
+(defn string->decimal [_ x]
+  (if (string? x)
+    (try
+      #?(:clj  (BigDecimal. x))
+      (catch #?(:clj Exception) _ x))
+    x))
+
 (defn string->uri [_ x]
   (if (string? x)
     (try
@@ -172,18 +179,18 @@
 
 (def json-type-decoders
   (merge
-    {:keyword string->keyword
-     :uuid (keyword-or-string-> string->uuid)
-     :date (keyword-or-string-> string->date)
-     :symbol (keyword-or-string-> string->symbol)
-     :long (keyword-> string->long)
-     :double (keyword-> string->double)
-     :boolean (keyword-> string->boolean)
-     :string keyword->string}
-    #?(:clj
-       {:uri string->uri
-        :bigdec nil
-        :ratio nil})))
+   {:keyword string->keyword
+    :uuid (keyword-or-string-> string->uuid)
+    :date (keyword-or-string-> string->date)
+    :symbol (keyword-or-string-> string->symbol)
+    :long (keyword-> string->long)
+    :double (keyword-> string->double)
+    :boolean (keyword-> string->boolean)
+    :string keyword->string}
+   #?(:clj
+      {:uri string->uri
+       :bigdec string->decimal
+       :ratio nil})))
 
 (def string-type-decoders
   (merge

--- a/test/cljc/spec_tools/transform_test.cljc
+++ b/test/cljc/spec_tools/transform_test.cljc
@@ -1,9 +1,14 @@
 (ns spec-tools.transform-test
   (:require [clojure.test :refer [deftest testing is]]
             [spec-tools.transform :as stt]
+            [clojure.test.check.generators :as gen]
+            [com.gfredericks.test.chuck.clojure-test :refer [checking]]
             #?@(:cljs [[goog.Uri]])))
 #?(:clj
    (:import java.net.URI))
+
+(def gen-bigdecimal
+  (gen/fmap #(BigDecimal. %) (gen/double* {:infinite? false :NaN? false})))
 
 (def _ ::irrelevant)
 
@@ -60,6 +65,19 @@
   (is (uri? (stt/string->uri _ "tel:+1-816-555-1212")))
   (is (uri? (stt/string->uri _ "urn:oasis:names:specification:docbook:dtd:xml:4.1.2")))
   (is (not (uri? (stt/string->uri _ nil)))))
+
+(deftest string->decimal
+  (is (decimal? (stt/string->decimal _ "42")))
+  (is (decimal? (stt/string->decimal _ "42.24")))
+  (is (not (decimal? (stt/string->decimal _ nil))))
+  (is (string? (stt/string->decimal _ "42.42M"))))
+
+(deftest properties-string->decimal
+  (checking "Scale and Precision must be preserved" 200
+            [original-bigdec gen-bigdecimal]
+            (let [new-bigdec (stt/string->decimal _ (str original-bigdec))]
+              (is (= (.scale original-bigdec) (.scale new-bigdec)))
+              (is (= (.precision original-bigdec) (.precision new-bigdec))))))
 
 (deftest string->date
   (is (= #inst "2018-04-27T18:25:37Z" (stt/string->date _ "2018-04-27T18:25:37Z")))

--- a/test/cljc/spec_tools/transform_test.cljc
+++ b/test/cljc/spec_tools/transform_test.cljc
@@ -66,18 +66,18 @@
   (is (uri? (stt/string->uri _ "urn:oasis:names:specification:docbook:dtd:xml:4.1.2")))
   (is (not (uri? (stt/string->uri _ nil)))))
 
-(deftest string->decimal
-  (is (decimal? (stt/string->decimal _ "42")))
-  (is (decimal? (stt/string->decimal _ "42.24")))
-  (is (not (decimal? (stt/string->decimal _ nil))))
-  (is (string? (stt/string->decimal _ "42.42M"))))
+#?(:clj (deftest string->decimal
+          (is (decimal? (stt/string->decimal _ "42")))
+          (is (decimal? (stt/string->decimal _ "42.24")))
+          (is (not (decimal? (stt/string->decimal _ nil))))
+          (is (string? (stt/string->decimal _ "42.42M")))))
 
-(deftest properties-string->decimal
-  (checking "Scale and Precision must be preserved" 200
-            [original-bigdec gen-bigdecimal]
-            (let [new-bigdec (stt/string->decimal _ (str original-bigdec))]
-              (is (= (.scale original-bigdec) (.scale new-bigdec)))
-              (is (= (.precision original-bigdec) (.precision new-bigdec))))))
+#?(:clj (deftest properties-string->decimal
+          (checking "Scale and Precision must be preserved" 200
+                    [original-bigdec gen-bigdecimal]
+                    (let [new-bigdec (stt/string->decimal _ (str original-bigdec))]
+                      (is (= (.scale original-bigdec) (.scale new-bigdec)))
+                      (is (= (.precision original-bigdec) (.precision new-bigdec)))))))
 
 (deftest string->date
   (is (= #inst "2018-04-27T18:25:37Z" (stt/string->date _ "2018-04-27T18:25:37Z")))


### PR DESCRIPTION
Adding a coercion for `bigdecimal` to the project.

Some examples from the tests added that should guarantee the expected behavior of the coercion:

```clojure
(decimal? (stt/string->decimal _ "42")) => true
(decimal? (stt/string->decimal _ "42.24")) => true
(not (decimal? (stt/string->decimal _ nil))) => true
(string? (stt/string->decimal _ "42.42M")) => true

```
There is also a property test to ensure that scale and precision must be respected when the conversion from string to decimal occur, i.e, 10.21 must have precision 4 and scale 2.