### PR TITLE
decimal coercion was only working for input datatype string

### DIFF
--- a/src/spec_tools/transform.cljc
+++ b/src/spec_tools/transform.cljc
@@ -36,6 +36,21 @@
     (cond
       (keyword? x) (f spec (keyword->string spec x))
       :else x)))
+
+;; Numbers
+;;
+
+(defn number->string [_ x]
+  (if (number? x)
+    (str x)
+    x))
+
+(defn number-or-string-> [f]
+  (fn [spec x]
+    (cond
+      (number? x) (f spec (number->string spec x))
+      (string? x) (f spec x)
+      :else x)))
 ;;
 ;; Strings
 ;;
@@ -190,7 +205,7 @@
      :string keyword->string}
     #?(:clj
        {:uri string->uri
-        :bigdec string->decimal
+        :bigdec (number-or-string-> string->decimal)
         :ratio nil})))
 
 (def string-type-decoders

--- a/test/cljc/spec_tools/transform_test.cljc
+++ b/test/cljc/spec_tools/transform_test.cljc
@@ -72,6 +72,13 @@
           (is (not (decimal? (stt/string->decimal _ nil))))
           (is (string? (stt/string->decimal _ "42.42M")))))
 
+#?(:clj (deftest number->decimal
+          (letfn [(num->decimal [n] ((stt/number-or-string-> stt/string->decimal) _ n))]
+            (is (decimal? (num->decimal 42)))
+            (is (decimal? (num->decimal 42.4224)))
+            (is (decimal? (num->decimal (Float. 42.4223))))
+            (is (decimal? (num->decimal (BigDecimal. 42.4222)))))))
+
 #?(:clj (deftest properties-string->decimal
           (checking "Scale and Precision must be preserved" 200
             [original-bigdec gen-bigdecimal]

--- a/test/cljc/spec_tools/transform_test.cljc
+++ b/test/cljc/spec_tools/transform_test.cljc
@@ -72,6 +72,12 @@
           (is (not (decimal? (stt/string->decimal _ nil))))
           (is (string? (stt/string->decimal _ "42.42M")))))
 
+(deftest number->string
+  (is (string? (stt/number->string _ 42.42)))
+  (is (string? (stt/number->string _ 42)))
+  (is (string? #?(:clj (stt/number->string _ (BigDecimal. 23123))
+                  :cljs (stt/number->string _ js/Math.PI)))))
+
 #?(:clj (deftest number->decimal
           (letfn [(num->decimal [n] ((stt/number-or-string-> stt/string->decimal) _ n))]
             (is (decimal? (num->decimal 42)))


### PR DESCRIPTION
However, I think it should work for numbers and "number stringified"
this issue was noticed while using reitit. The following scenario:

initial setup: build a `decimal?` validation spec and performing the
following experiment:

1. using the spec in a route using `:form` parameters
2. using the spec in a route using `:body` parameters

The 1. works just fine as expected and 2. doesn't. And the reason is
related with `:form` parameters getting all the inputs as strings by
definition while the body of a json maintains the numeric datatypes.

This following PR attempts to fix this issue by coercion numeric
datatypes to bigdecimals too.