### PR TITLE
bugfix to make the coercion work properly with s/or

### DIFF
--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -286,10 +286,9 @@
    (fn [v item]
      (let [transformed (accept item v options)
            valid? (valid-spec item transformed)]
-       (cond
-         valid? (reduced transformed)
-         (not valid?) transformed
-         :else (reduced transformed))))
+       (if valid?
+         (reduced transformed)
+         transformed)))
    value items))
 
 (defmethod walk :and [{:keys [::parse/items]} value accept options]

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -279,7 +279,8 @@
    (fn [v item]
      (let [transformed (accept item v options)
            valid-branch? (s/valid? (create-spec item) transformed)
-           any-spec? (= (:form spec) 'clojure.core/any?)]
+           any-spec? (= (:form spec) #?(:clj 'clojure.core/any?
+                                        :cljs 'cljs.core/any?))]
        (cond
          (and valid-branch? (not any-spec?)) (reduced transformed)
          (= transformed v) v

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -274,12 +274,17 @@
     (accept spec value (assoc options :skip? true))
     value))
 
-(defmethod walk :or [{:keys [::parse/items]} value accept options]
+(defmethod walk :or [{:keys [::parse/items] :as spec} value accept options]
   (reduce
-    (fn [v item]
-      (let [transformed (accept item v options)]
-        (if (= transformed v) v (reduced transformed))))
-    value items))
+   (fn [v item]
+     (let [transformed (accept item v options)
+           valid-branch? (s/valid? (create-spec item) transformed)
+           any-spec? (= (:form spec) 'clojure.core/any?)]
+       (cond
+         (and valid-branch? (not any-spec?)) (reduced transformed)
+         (= transformed v) v
+         :else (reduced transformed))))
+   value items))
 
 (defmethod walk :and [{:keys [::parse/items]} value accept options]
   (reduce

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -798,3 +798,23 @@
              (st/decode spec "114.0" st/string-transformer)
              (st/conform spec "114.0" st/string-transformer)
              (st/coerce spec "114.0" st/string-transformer))))))
+
+(s/def ::car (s/keys :req-un [::doors]))
+(s/def ::bike (s/keys :req-un [::wheels]))
+(s/def ::tires (s/coll-of (s/and int?) :into #{}))
+(s/def ::vehicle (s/or :car ::car
+                       :bike ::bike))
+(s/def ::new-vehicle (s/map-of
+                      keyword?
+                      (s/or :vehicle ::vehicle
+                            :tires (s/coll-of (s/and int?) :into #{}))))
+
+(deftest issue-179
+  (testing "st/coerce can work properly with s/or specs"
+    (let [chevy {:doors 4}]
+      (is (= (st/coerce ::car chevy st/strip-extra-keys-transformer)
+             {:doors 4}))
+      (is (= (st/coerce ::vehicle chevy st/strip-extra-keys-transformer)
+             {:doors 4}))
+      (is (= (st/coerce ::new-vehicle {:rodas [1 "1" 3]} st/strip-extra-keys-transformer)
+             {:rodas #{1 "1" 3}})))))

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -804,10 +804,17 @@
 (s/def ::tires (s/coll-of (s/and int?) :into #{}))
 (s/def ::vehicle (s/or :car ::car
                        :bike ::bike))
+
 (s/def ::new-vehicle (s/map-of
                       keyword?
                       (s/or :vehicle ::vehicle
                             :tires (s/coll-of (s/and int?) :into #{}))))
+
+(s/def ::keyword keyword?)
+(s/def ::int int?)
+(s/def ::date inst?)
+(s/def ::s (s/or :x (s/keys :req-un [::keyword ::int])
+                 :y (s/keys :req-un [::keyword ::date])))
 
 (deftest issue-179
   (testing "st/coerce can work properly with s/or specs"
@@ -817,4 +824,6 @@
       (is (= (st/coerce ::vehicle chevy st/strip-extra-keys-transformer)
              {:doors 4}))
       (is (= (st/coerce ::new-vehicle {:rodas [1 "1" 3]} st/strip-extra-keys-transformer)
-             {:rodas #{1 "1" 3}})))))
+             {:rodas #{1 "1" 3}}))
+      (is (= (st/coerce ::s {:keyword "a" :date "2020-02-22"} st/json-transformer)
+             {:keyword :a :date #inst "2020-02-22T00:00:00.000-00:00"})))))


### PR DESCRIPTION
Fixes #178 . The solution is a bit more convoluted than I expected because of the special case for `clojure.core/any?` forms that would introduce a bug if I stopped the reduce operation when I first get a valid data from a or spec.

The example provided in the issue is now working as expected:

```clj
(st/coerce ::vehicle chevy st/strip-extra-keys-transformer)
;; => {:doors 4}
```