### PR TITLE
suggestion for fixing how to deal with symbols in merge of two specs

### DIFF
--- a/src/spec_tools/impl.cljc
+++ b/src/spec_tools/impl.cljc
@@ -91,10 +91,15 @@
            res (if cljs? (partial cljs-resolve env) clojure.core/resolve)]
        (->> pred
             (walk/postwalk
-              (fn [x]
-                (if (symbol? x)
-                  (or (some->> x res ->sym) x)
-                  x)))
+             (fn [x]
+               (if (symbol? x)
+                 (let [x' (res x)]
+                   (if (var? x')
+                     (if (s/get-spec (var-get x'))
+                       (var-get x')
+                       (->sym x'))
+                     x))
+                 x)))
             (unfn cljs?)))))
 
 (defn extract-pred-and-info [x]

--- a/src/spec_tools/impl.cljc
+++ b/src/spec_tools/impl.cljc
@@ -93,12 +93,15 @@
             (walk/postwalk
              (fn [x]
                (if (symbol? x)
-                 (let [x' (res x)]
-                   (if (var? x')
-                     (if (s/get-spec (var-get x'))
-                       (var-get x')
-                       (->sym x'))
-                     x))
+                 (let [y (res x)
+                       -var-get (fn [v] (if cljs? @v (var-get v)))
+                       sym-or-x (fn [v] (or (->sym v) x))]
+                   (cond
+                     (var? y) (if (s/get-spec (-var-get y))
+                                (-var-get y)
+                                (sym-or-x y))
+                     (some? y) (sym-or-x y)
+                     :else x))
                  x)))
             (unfn cljs?)))))
 

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -798,3 +798,16 @@
              (st/decode spec "114.0" st/string-transformer)
              (st/conform spec "114.0" st/string-transformer)
              (st/coerce spec "114.0" st/string-transformer))))))
+
+(s/def ::foo string?)
+(s/def ::bar string?)
+(s/def ::qix (s/keys :req-un [::foo]))
+(s/def ::qux (s/keys :req-un [::bar]))
+
+(def qix ::qix)
+
+#?(:clj
+   (deftest issue-201
+     (testing "merge should work with symbols too"
+       (is (st/spec? (st/merge ::qix ::qux)))
+       (is (st/spec? (st/merge qix ::qux))))))


### PR DESCRIPTION
A proposed fix for issue #201 , this was the best attempt so far without using `eval` to accomplish the task. 