### PR TITLE
allow option to toggle title inference from specs

### DIFF
--- a/docs/04_json_schema.md
+++ b/docs/04_json_schema.md
@@ -30,6 +30,25 @@ Utility to transform Specs into JSON Schemas. The generated schema conforms to [
 ; :title "user/user"}
 ```
 
+You also has an option to disable the title inference from specs that
+does not have an explicit `:name` attribute assigned to them, see more
+details below. Therefore, the current example would become:
+
+```clj
+(json-schema/transform ::user {:infer-titles false})
+;{:type "object"
+; :properties {"id" {:type "string"}
+;              "name" {:type "string"}
+;              "address" {:type "object"
+;                         :properties {"street" {:type "string"}
+;                                      "city" {:enum [:tre :hki]}}
+;                         :required ["street" "city"]
+;                         }}
+; :required ["id" "name" "address"]}
+```
+
+
+
 ## Annotated Specs
 
 Specs can be annotated to populate the JSON Schemas.

--- a/test/cljc/spec_tools/json_schema_test.cljc
+++ b/test/cljc/spec_tools/json_schema_test.cljc
@@ -127,6 +127,17 @@
     (is (not= (jsc/transform (s/coll-of (s/tuple string? any?) :into {}))
               {:type "object", :additionalProperties {:type "string"}}))))
 
+(s/def ::id string?)
+(s/def ::age string?)
+(s/def ::zipcode string?)
+(s/def ::user (s/keys :req-un [::id ::age]))
+(s/def ::address (s/keys :req-un [::user ::zipcode]))
+
+(deftest infer-schema-titles-test
+  (is (some? (:title (jsc/transform ::address))))
+  (is (nil? (:title (jsc/transform ::address {:infer-titles false}))))
+  (is (some? (:title (jsc/transform ::address {:infer-titles true})))))
+
 #?(:clj
    (defn test-spec-conversion [spec]
      (let [validate (scjsv/validator (jsc/transform spec))]


### PR DESCRIPTION
Implementation of the issue described in #198 . As `maybe-with-titles` is a private function, I choose to change its default arity instead of adding a new one to prevent possible api breakage because I needed to change all calls to it, therefore would not make much sense anyway.

Added a piece of documentation as well in the docs about json-schema.