### PR TITLE
fixed the warning message in cljs test suite

### DIFF
--- a/test/cljc/spec_tools/transform_test.cljc
+++ b/test/cljc/spec_tools/transform_test.cljc
@@ -1,14 +1,14 @@
 (ns spec-tools.transform-test
   (:require [clojure.test :refer [deftest testing is]]
             [spec-tools.transform :as stt]
-            [clojure.test.check.generators :as gen]
-            [com.gfredericks.test.chuck.clojure-test :refer [checking]]
+            #?(:clj [clojure.test.check.generators :as gen])
+            #?(:clj [com.gfredericks.test.chuck.clojure-test :refer [checking]])
             #?@(:cljs [[goog.Uri]])))
 #?(:clj
    (:import java.net.URI))
 
-(def gen-bigdecimal
-  (gen/fmap #(BigDecimal. %) (gen/double* {:infinite? false :NaN? false})))
+#?(:clj (def gen-bigdecimal
+          (gen/fmap #(BigDecimal. %) (gen/double* {:infinite? false :NaN? false}))))
 
 (def _ ::irrelevant)
 


### PR DESCRIPTION
After looking at it several times I got a little annoyed by the warnings at cljs test suite. (even more because I introduced this thing in the code)

```
WARNING: Use of undeclared Var spec-tools.transform-test/BigDecimal at line 11 /home/wand/spec-tools/test/cljc/spec_tools/transform_test.cljc
WARNING: Use of undeclared Var spec-tools.transform-test/BigDecimal at line 11 /home/wand/spec-tools/test/cljc/spec_tools/transform_test.cljc
```

This is the small fix needed to change it.