### PR TITLE
fixing missing titles with s/cat and s/merge

### DIFF
--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -204,24 +204,26 @@
 (defmethod accept-spec 'clojure.spec.alpha/and [_ _ children _]
   (simplify-all-of {:allOf children}))
 
-(defn- accept-merge [children]
-  {:type "object"
-   :properties (->> (concat children
-                            (mapcat :anyOf children)
-                            (mapcat :allOf children))
-                    (map :properties)
-                    (reduce merge {}))
-   :required (->> (concat children
-                          (mapcat :allOf children))
-                  (map :required)
-                  (reduce into (sorted-set))
-                  (into []))})
+(defn- accept-merge [children spec options]
+  (maybe-with-title
+   {:type "object"
+    :properties (->> (concat children
+                             (mapcat :anyOf children)
+                             (mapcat :allOf children))
+                     (map :properties)
+                     (reduce merge {}))
+    :required (->> (concat children
+                           (mapcat :allOf children))
+                   (map :required)
+                   (reduce into (sorted-set))
+                   (into []))}
+   spec))
 
-(defmethod accept-spec 'clojure.spec.alpha/merge [_ _ children _]
-  (accept-merge children))
+(defmethod accept-spec 'clojure.spec.alpha/merge [_ spec children options]
+  (accept-merge children spec options))
 
-(defmethod accept-spec 'spec-tools.core/merge [_ _ children _]
-  (accept-merge children))
+(defmethod accept-spec 'spec-tools.core/merge [_ spec children options]
+  (accept-merge children spec options))
 
 (defmethod accept-spec 'clojure.spec.alpha/every [_ spec children _]
   (let [form (impl/extract-form spec)
@@ -252,12 +254,16 @@
 (defmethod accept-spec 'clojure.spec.alpha/? [_ _ children _]
   {:type "array" :items (impl/unwrap children) :minItems 0})
 
-(defmethod accept-spec 'clojure.spec.alpha/alt [_ _ children _]
-  {:anyOf children})
+(defmethod accept-spec 'clojure.spec.alpha/alt [_ spec children options]
+  (maybe-with-title
+   {:anyOf children}
+   spec))
 
-(defmethod accept-spec 'clojure.spec.alpha/cat [_ _ children _]
-  {:type "array"
-   :items {:anyOf children}})
+(defmethod accept-spec 'clojure.spec.alpha/cat [_ spec children options]
+  (maybe-with-title
+   {:type "array"
+    :items {:anyOf children}}
+   spec))
 
 ; &
 


### PR DESCRIPTION
Hi! This PR attempt to solve #197 however there are some points I wanted to make clear.

1. I might be obvious, but the `:title` will be show up only if your `s/merge` or `s/cat` is defined because
```clj
(st/spec-name (s/merge ::one ::two)) ;; => nil
```
Therefore, only if you use something like:
```clj
(s/def ::merged (s/merge ::one ::two))
(st/spec-name ::merged) ;; => full-qualified/merged
```

2. This PR depends on another open PR #221 which will enable the title added by this PR to be customizable by the end user. However, I am not sure how to deal with this dependency here. What I end up doing was to leave this PR completely independent from the other one and once both of them is merged I will open a new one finishing the work. I did this because the other PR is more opiniated and if we have implementations change it could affect this one too.

Thks