### PR TITLE
we don't need to pass custom values to swagger using namespaced keys

### DIFF
--- a/src/spec_tools/swagger/core.cljc
+++ b/src/spec_tools/swagger/core.cljc
@@ -78,7 +78,8 @@
 
 (defmethod accept-spec ::visitor/spec [dispatch spec children options]
   (let [[_ data] (impl/extract-form spec)
-        swagger-meta (impl/unlift-keys data "swagger")]
+        swagger-meta (impl/unlift-keys data "swagger")
+        swagger-meta (merge (:swagger data) swagger-meta)]
     (merge (json-schema/accept-spec dispatch spec children options) swagger-meta)))
 
 (defmethod accept-spec ::default [dispatch spec children options]

--- a/test/cljc/spec_tools/swagger/core_test.cljc
+++ b/test/cljc/spec_tools/swagger/core_test.cljc
@@ -370,3 +370,25 @@
                                                                        :description "Found it!"}
                                                                   404 {:description "Ohnoes."}}}}}}]
        (is (nil? (-> data swagger/swagger-spec v/validate))))))
+
+
+(deftest backport-swagger-meta-unnamespaced
+  (is (= (swagger/transform
+          (st/spec {:spec    string?
+                    :swagger {:type   "string"
+                              :format "password"
+                              :random-value "42"}}))
+         {:type "string" :format "password" :random-value "42"}))
+
+  (is (= (swagger/transform
+          (st/spec {:spec string?
+                    :swagger {:type "string"}
+                    :swagger/format "password"}))
+         {:type "string" :format "password"}))
+
+  (is (= (swagger/transform
+          (st/spec {:spec string?
+                    :swagger/type "string"
+                    :swagger/format "password"
+                    :swagger/random-value "42"}))
+         {:type "string" :format "password" :random-value "42"})))


### PR DESCRIPTION
As a small confusion caused by passing a _password_ value to
swagger at reitit reported by Mark Bastian, this is a backport of the
malli functionality for not using namespaced :swagger keys to handle
those custom parameters.

Both examples below are now interchangeable.

```clj
(st/spec {:spec string?
          :swagger {:type "string"
                    :format "password"}})
;;=> {:type "string" :format "password"}
```

```clj
(st/spec {:spec string?
          :swagger/type "string"
          :swagger/format "password"})
;;=> {:type "string" :format "password"}
```

You can even mix both of them if you dont have OCD like me rsrs
```clj
(st/spec {:spec string?
          :swagger {:type "string"}
          :swagger/format "password"})
;;=> {:type "string" :format "password"}
```
