### PR TITLE
spec coll-of distinguish between set and vector data types

### DIFF
--- a/src/spec_tools/impl.cljc
+++ b/src/spec_tools/impl.cljc
@@ -182,14 +182,15 @@
 ;;
 
 (defn coll-of-spec [pred type]
-  (let [form (form/resolve-form pred)]
+  (let [form (form/resolve-form pred)
+        cpred (if (set? type) set? vector?)]
     (clojure.spec.alpha/every-impl
       form
       pred
       {:into type
        ::s/conform-all true
        ::s/describe `(s/coll-of ~form :into ~type),
-       ::s/cpred coll?,
+       ::s/cpred cpred,
        ::s/kind-form (quote nil)}
       nil)))
 

--- a/src/spec_tools/impl.cljc
+++ b/src/spec_tools/impl.cljc
@@ -205,7 +205,7 @@
        ::s/kfn (fn [_ v] (nth v 0))
        ::s/conform-all true
        ::s/describe `(s/map-of ~@forms :conform-keys true),
-       ::s/cpred coll?,
+       ::s/cpred map?,
        ::s/kind-form (quote nil)}
       nil)))
 

--- a/test/cljc/spec_tools/impl_test.cljc
+++ b/test/cljc/spec_tools/impl_test.cljc
@@ -59,11 +59,15 @@
 
 (deftest coll-of-specs-distinguish-between-data-types
   (let [spec-set (impl/coll-of-spec int? #{})
-        spec-vec (impl/coll-of-spec int? [])]
+        spec-vec (impl/coll-of-spec int? [])
+        spec-map (impl/map-of-spec int? int?)]
     (is (= true (s/valid? spec-set #{1 2 3})))
     (is (= false (s/valid? spec-set [1 2 3])))
     (is (= true (s/valid? spec-vec [1 2 3])))
-    (is (= false (s/valid? spec-vec #{1 2 3})))))
+    (is (= false (s/valid? spec-vec #{1 2 3})))
+    (is (= true (s/valid? spec-map {4 2})))
+    (is (= false (s/valid? spec-map #{[1 2]})))
+    (is (= false (s/valid? spec-map #{1 2 3 4})))))
 
 (deftest map-of-spec-tests
   (let [spec (s/map-of string? string? :conform-keys true)

--- a/test/cljc/spec_tools/impl_test.cljc
+++ b/test/cljc/spec_tools/impl_test.cljc
@@ -57,6 +57,14 @@
            (s/conform spec ["1"])
            (s/conform impl ["1"])))))
 
+(deftest coll-of-specs-distinguish-between-data-types
+  (let [spec-set (impl/coll-of-spec int? #{})
+        spec-vec (impl/coll-of-spec int? [])]
+    (is (= true (s/valid? spec-set #{1 2 3})))
+    (is (= false (s/valid? spec-set [1 2 3])))
+    (is (= true (s/valid? spec-vec [1 2 3])))
+    (is (= false (s/valid? spec-vec #{1 2 3})))))
+
 (deftest map-of-spec-tests
   (let [spec (s/map-of string? string? :conform-keys true)
         impl (impl/map-of-spec string? string?)]


### PR DESCRIPTION
Fixes the bug reported at #237 . Seems like the function `impl/coll-of-spec` has a property called `cpred` which was default to `coll?` however, both sets and vectors returns true to `coll?`. I made a change to verify the type of argument passed to the function, so the `cpred` is chosen apropriately.

Thus the OP example now has the expected behavior:

```clj
(s/valid? (ds/spec ::x #{int?}) #{1 2 3})  ;; => true
(s/valid? (ds/spec ::x #{int?}) [1 2 3])  ;; => false
```