### PR TITLE
Bugfix/recursive parse spec

### DIFF
--- a/src/spec_tools/parse.cljc
+++ b/src/spec_tools/parse.cljc
@@ -19,46 +19,50 @@
   "Parses info out of a spec. Spec can be passed as a name, Spec or a form.
   Returns either `nil` or a map, with keys `:type` and other extra keys
   (like `:keys` for s/keys specs)."
-  [x]
-  (cond
+  ([x]
+   (parse-spec x nil))
+  ([x options]
+   (cond
 
-    ;; unknown
-    (= ::s/unknown x)
-    nil
+     ;; unknown
+     (= ::s/unknown x)
+     nil
 
-    ;; spec name
-    (qualified-keyword? x)
-    (recur (s/form (s/get-spec x)))
+     ;; spec name - handle in the two arity version to account for recursive calls
+     (qualified-keyword? x)
+     (if (get (::visited options) x)
+       {:spec x}
+       (parse-spec (s/form (s/get-spec x)) (update options ::visited (fnil conj #{}) x)))
+     
+     ;; symbol
+     (symbol? x)
+     (parse-form (impl/normalize-symbol x) nil options)
 
-    ;; symbol
-    (symbol? x)
-    (parse-form (impl/normalize-symbol x) nil)
+     ;; a form
+     (seq? x)
+     (parse-form (impl/normalize-symbol (first x)) x options)
 
-    ;; a form
-    (seq? x)
-    (parse-form (impl/normalize-symbol (first x)) x)
+     ;; a spec
+     (s/spec? x)
+     (recur (s/form x) options)
 
-    ;; a spec
-    (s/spec? x)
-    (recur (s/form x))
+     ;; a predicate
+     (ifn? x)
+     (parse-form (impl/normalize-symbol (form/resolve-form x)) nil options)
 
-    ;; a predicate
-    (ifn? x)
-    (parse-form (impl/normalize-symbol (form/resolve-form x)) nil)
+     ;; default
+     :else (parse-form x nil options))))
 
-    ;; default
-    :else (parse-form x nil)))
-
-(defn parse-spec-with-spec-ref [x]
-  (merge (parse-spec x) (if (qualified-keyword? x) {:spec x})))
+(defn parse-spec-with-spec-ref [x options]
+  (merge (parse-spec x options) (if (qualified-keyword? x) {:spec x})))
 
 (defn get-keys [parse-data]
   (or (::keys parse-data)
       (some->> parse-data ::items (keep get-keys) (apply concat) (seq) (set))))
 
-(defmulti parse-form (fn [dispatch _] dispatch) :default ::default)
+(defmulti parse-form (fn [dispatch _ _] dispatch) :default ::default)
 
-(defmethod parse-form ::default [_ _] {:type nil})
+(defmethod parse-form ::default [_ _ _] {:type nil})
 
 (defn- non-leaf-types []
   #{:map :map-of :and :or :nilable :tuple :set :vector :multi-spec})
@@ -93,54 +97,54 @@
       (->> (filter symbol?))
       set))
 
-(defmethod parse-form 'clojure.core/any?               [_ _] {:spec any?})
-(defmethod parse-form 'clojure.core/some?              [_ _] {:spec some?})
-(defmethod parse-form 'clojure.core/number?            [_ _] {:spec number?, :type :double})
-(defmethod parse-form 'clojure.core/integer?           [_ _] {:spec integer?, :type :long})
-(defmethod parse-form 'clojure.core/int?               [_ _] {:spec int?, :type :long})
-(defmethod parse-form 'clojure.core/pos-int?           [_ _] {:spec pos-int?, :type :long})
-(defmethod parse-form 'clojure.core/neg-int?           [_ _] {:spec neg-int?, :type :long})
-(defmethod parse-form 'clojure.core/nat-int?           [_ _] {:spec nat-int?, :type :long})
-(defmethod parse-form 'clojure.core/float?             [_ _] {:spec float?, :type :double})
-(defmethod parse-form 'clojure.core/double?            [_ _] {:spec double?, :type :double})
-(defmethod parse-form 'clojure.core/boolean?           [_ _] {:spec boolean?, :type :boolean})
-(defmethod parse-form 'clojure.core/string?            [_ _] {:spec string?, :type :string})
-(defmethod parse-form 'clojure.core/ident?             [_ _] {:spec ident? :type :keyword})
-(defmethod parse-form 'clojure.core/simple-ident?      [_ _] {:spec simple-ident?, :type :keyword})
-(defmethod parse-form 'clojure.core/qualified-ident?   [_ _] {:spec qualified-ident?, :type :keyword})
-(defmethod parse-form 'clojure.core/keyword?           [_ _] {:spec keyword?, :type :keyword})
-(defmethod parse-form 'clojure.core/simple-keyword?    [_ _] {:spec simple-keyword?, :type :keyword})
-(defmethod parse-form 'clojure.core/qualified-keyword? [_ _] {:spec qualified-keyword? :type :keyword})
-(defmethod parse-form 'clojure.core/symbol?            [_ _] {:spec symbol?, :type :symbol})
-(defmethod parse-form 'clojure.core/simple-symbol?     [_ _] {:spec simple-symbol?, :type :symbol})
-(defmethod parse-form 'clojure.core/qualified-symbol?  [_ _] {:spec qualified-symbol?, :type :symbol})
-(defmethod parse-form 'clojure.core/uuid?              [_ _] {:spec uuid?, :type :uuid})
-#?(:clj (defmethod parse-form 'clojure.core/uri?       [_ _] {:spec uri?, :type :uri}))
-#?(:clj (defmethod parse-form 'clojure.core/decimal?   [_ _] {:spec decimal?, :type :bigdec}))
-(defmethod parse-form 'clojure.core/inst?              [_ _] {:spec inst?, :type :date})
-(defmethod parse-form 'clojure.core/seqable?           [_ _] {:spec seqable?})
-(defmethod parse-form 'clojure.core/indexed?           [_ _] {:spec indexed?})
-(defmethod parse-form 'clojure.core/map?               [_ _] {:spec map?})
-(defmethod parse-form 'clojure.core/vector?            [_ _] {:spec vector?})
-(defmethod parse-form 'clojure.core/list?              [_ _] {:spec list?})
-(defmethod parse-form 'clojure.core/seq?               [_ _] {:spec seq?})
-(defmethod parse-form 'clojure.core/char?              [_ _] {:spec char?})
-(defmethod parse-form 'clojure.core/set?               [_ _] {:spec set?})
-(defmethod parse-form 'clojure.core/nil?               [_ _] {:spec nil?})
-(defmethod parse-form 'clojure.core/false?             [_ _] {:spec false?, :type :boolean})
-(defmethod parse-form 'clojure.core/true?              [_ _] {:spec true?, :type :boolean})
-(defmethod parse-form 'clojure.core/zero?              [_ _] {:spec zero?, :type :long})
-#?(:clj (defmethod parse-form 'clojure.core/rational?  [_ _] {:spec rational?, :type :long}))
-(defmethod parse-form 'clojure.core/coll?              [_ _] {:spec coll?})
-(defmethod parse-form 'clojure.core/empty?             [_ _] {:spec empty?})
-(defmethod parse-form 'clojure.core/associative?       [_ _] {:spec associative?, :type nil})
-(defmethod parse-form 'clojure.core/sequential?        [_ _] {:spec sequential?})
-#?(:clj (defmethod parse-form 'clojure.core/ratio?     [_ _] {:spec ratio?, :type :ratio}))
-#?(:clj (defmethod parse-form 'clojure.core/bytes?     [_ _] {:spec bytes?}))
+(defmethod parse-form 'clojure.core/any?               [_ _ _] {:spec any?})
+(defmethod parse-form 'clojure.core/some?              [_ _ _] {:spec some?})
+(defmethod parse-form 'clojure.core/number?            [_ _ _] {:spec number?, :type :double})
+(defmethod parse-form 'clojure.core/integer?           [_ _ _] {:spec integer?, :type :long})
+(defmethod parse-form 'clojure.core/int?               [_ _ _] {:spec int?, :type :long})
+(defmethod parse-form 'clojure.core/pos-int?           [_ _ _] {:spec pos-int?, :type :long})
+(defmethod parse-form 'clojure.core/neg-int?           [_ _ _] {:spec neg-int?, :type :long})
+(defmethod parse-form 'clojure.core/nat-int?           [_ _ _] {:spec nat-int?, :type :long})
+(defmethod parse-form 'clojure.core/float?             [_ _ _] {:spec float?, :type :double})
+(defmethod parse-form 'clojure.core/double?            [_ _ _] {:spec double?, :type :double})
+(defmethod parse-form 'clojure.core/boolean?           [_ _ _] {:spec boolean?, :type :boolean})
+(defmethod parse-form 'clojure.core/string?            [_ _ _] {:spec string?, :type :string})
+(defmethod parse-form 'clojure.core/ident?             [_ _ _] {:spec ident? :type :keyword})
+(defmethod parse-form 'clojure.core/simple-ident?      [_ _ _] {:spec simple-ident?, :type :keyword})
+(defmethod parse-form 'clojure.core/qualified-ident?   [_ _ _] {:spec qualified-ident?, :type :keyword})
+(defmethod parse-form 'clojure.core/keyword?           [_ _ _] {:spec keyword?, :type :keyword})
+(defmethod parse-form 'clojure.core/simple-keyword?    [_ _ _] {:spec simple-keyword?, :type :keyword})
+(defmethod parse-form 'clojure.core/qualified-keyword? [_ _ _] {:spec qualified-keyword? :type :keyword})
+(defmethod parse-form 'clojure.core/symbol?            [_ _ _] {:spec symbol?, :type :symbol})
+(defmethod parse-form 'clojure.core/simple-symbol?     [_ _ _] {:spec simple-symbol?, :type :symbol})
+(defmethod parse-form 'clojure.core/qualified-symbol?  [_ _ _] {:spec qualified-symbol?, :type :symbol})
+(defmethod parse-form 'clojure.core/uuid?              [_ _ _] {:spec uuid?, :type :uuid})
+#?(:clj (defmethod parse-form 'clojure.core/uri?       [_ _ _] {:spec uri?, :type :uri}))
+#?(:clj (defmethod parse-form 'clojure.core/decimal?   [_ _ _] {:spec decimal?, :type :bigdec}))
+(defmethod parse-form 'clojure.core/inst?              [_ _ _] {:spec inst?, :type :date})
+(defmethod parse-form 'clojure.core/seqable?           [_ _ _] {:spec seqable?})
+(defmethod parse-form 'clojure.core/indexed?           [_ _ _] {:spec indexed?})
+(defmethod parse-form 'clojure.core/map?               [_ _ _] {:spec map?})
+(defmethod parse-form 'clojure.core/vector?            [_ _ _] {:spec vector?})
+(defmethod parse-form 'clojure.core/list?              [_ _ _] {:spec list?})
+(defmethod parse-form 'clojure.core/seq?               [_ _ _] {:spec seq?})
+(defmethod parse-form 'clojure.core/char?              [_ _ _] {:spec char?})
+(defmethod parse-form 'clojure.core/set?               [_ _ _] {:spec set?})
+(defmethod parse-form 'clojure.core/nil?               [_ _ _] {:spec nil?})
+(defmethod parse-form 'clojure.core/false?             [_ _ _] {:spec false?, :type :boolean})
+(defmethod parse-form 'clojure.core/true?              [_ _ _] {:spec true?, :type :boolean})
+(defmethod parse-form 'clojure.core/zero?              [_ _ _] {:spec zero?, :type :long})
+#?(:clj (defmethod parse-form 'clojure.core/rational?  [_ _ _] {:spec rational?, :type :long}))
+(defmethod parse-form 'clojure.core/coll?              [_ _ _] {:spec coll?})
+(defmethod parse-form 'clojure.core/empty?             [_ _ _] {:spec empty?})
+(defmethod parse-form 'clojure.core/associative?       [_ _ _] {:spec associative?, :type nil})
+(defmethod parse-form 'clojure.core/sequential?        [_ _ _] {:spec sequential?})
+#?(:clj (defmethod parse-form 'clojure.core/ratio?     [_ _ _] {:spec ratio?, :type :ratio}))
+#?(:clj (defmethod parse-form 'clojure.core/bytes?     [_ _ _] {:spec bytes?}))
 
-(defmethod parse-form :clojure.spec.alpha/unknown [_ _])
+(defmethod parse-form :clojure.spec.alpha/unknown [_ _ _])
 
-(defmethod parse-form 'clojure.spec.alpha/keys [_ form]
+(defmethod parse-form 'clojure.spec.alpha/keys [_ form _]
   (let [{:keys [req opt req-un opt-un key->spec]} (impl/parse-keys form)]
     (cond-> {:type :map
              ::key->spec key->spec
@@ -172,32 +176,37 @@
               (map (fn [[spec-k method]]
                      [spec-k (method nil)])))))))
 
-(defmethod parse-form 'clojure.spec.alpha/multi-spec [_ form]
+(defmethod parse-form 'clojure.spec.alpha/multi-spec [_ form _]
   {:type :multi-spec
    ::key (last form)
    ::dispatch (into {} (get-multi-spec-sub-specs form))})
 
-(defmethod parse-form 'clojure.spec.alpha/or [_ form]
-  (let [specs (mapv (comp parse-spec-with-spec-ref second) (partition 2 (rest form)))]
+(defmethod parse-form 'clojure.spec.alpha/or [_ form options]
+  (let [specs (mapv (comp #(parse-spec-with-spec-ref % options) second) (partition 2 (rest form)))]
     {:type [:or (->> specs (map :type) (distinct) (keep identity) (vec))]
      ::items specs}))
 
-(defmethod parse-form 'clojure.spec.alpha/and [_ form]
-  (let [specs (mapv parse-spec-with-spec-ref (rest form))
+(defmethod parse-form 'clojure.spec.alpha/and [_ form options]
+  (let [specs (mapv #(parse-spec-with-spec-ref % options) (rest form))
         types (->> specs (map :type) (distinct) (keep identity) (vec))]
     {:type [:and types]
      ::items specs}))
 
+<<<<<<< HEAD
 (defmethod parse-form 'clojure.spec.alpha/merge [_ form]
   (let [type-priority #((:type %) {:map 0
                                    :multi-spec 1} 0)]
+=======
+(defmethod parse-form 'clojure.spec.alpha/merge [_ form options]
+  (let [type-priority #(if (= (:type %) :multi-spec) 1 0)]
+>>>>>>> cf0ce10 (fix recursive parse-spec visits)
     (apply impl/deep-merge (->> (rest form)
-                                (map parse-spec)
+                                (map #(parse-spec % options))
                                 (sort-by type-priority)))))
 
-(defmethod parse-form 'clojure.spec.alpha/every [_ form]
+(defmethod parse-form 'clojure.spec.alpha/every [_ form options]
   (let [{:keys [into]} (apply hash-map (drop 2 form))]
-    {::item (parse-spec (second form))
+    {::item (parse-spec (second form) options)
      :type
      (cond
        (map? into) :map-of
@@ -206,22 +215,22 @@
 
 ; every-ks
 
-(defmethod parse-form 'clojure.spec.alpha/coll-of [_ form]
+(defmethod parse-form 'clojure.spec.alpha/coll-of [_ form options]
   (let [{:keys [into]} (apply hash-map (drop 2 form))]
-    {::item (parse-spec-with-spec-ref (second form))
+    {::item (parse-spec-with-spec-ref (second form) options)
      :type
      (cond
        (map? into) :map-of
        (set? into) :set
        :else :vector)}))
 
-(defmethod parse-form 'clojure.spec.alpha/map-of [_ [_ k v]]
+(defmethod parse-form 'clojure.spec.alpha/map-of [_ [_ k v] options]
   {:type :map-of
-   ::key (parse-spec-with-spec-ref k)
-   ::value (parse-spec-with-spec-ref v)})
+   ::key (parse-spec-with-spec-ref k options)
+   ::value (parse-spec-with-spec-ref v options)})
 
-(defmethod parse-form 'spec-tools.core/spec [_ form]
-  (let [parsed (-> form last :spec parse-spec)]
+(defmethod parse-form 'spec-tools.core/spec [_ form options]
+  (let [parsed (-> form last :spec (parse-spec options))]
     (if (:type parsed) parsed {:type :spec})))
 
 ; *
@@ -232,20 +241,20 @@
 ; &
 ; keys*
 
-(defmethod parse-form 'clojure.spec.alpha/tuple [_ [_ & values]]
-  (let [specs (mapv parse-spec-with-spec-ref values)
+(defmethod parse-form 'clojure.spec.alpha/tuple [_ [_ & values] options]
+  (let [specs (mapv #(parse-spec-with-spec-ref % options) values)
         types (mapv :type specs)]
     {:type [:tuple types]
      ::items specs}))
 
-(defmethod parse-form 'clojure.spec.alpha/nilable [_ form]
-  (let [spec (-> form second parse-spec-with-spec-ref)]
+(defmethod parse-form 'clojure.spec.alpha/nilable [_ form options]
+  (let [spec (-> form second (parse-spec-with-spec-ref options))]
     {:type :nilable
      ::item spec}))
 
-(defmethod parse-form 'spec-tools.core/merge [_ form]
+(defmethod parse-form 'spec-tools.core/merge [_ form options]
   (let [type-priority #((:type %) {:map 1
                                    :multi-spec 0})]
     (apply impl/deep-merge (->> (rest form)
-                                (map parse-spec)
+                                (map #(parse-spec % options))
                                 (sort-by type-priority)))))

--- a/src/spec_tools/parse.cljc
+++ b/src/spec_tools/parse.cljc
@@ -192,14 +192,8 @@
     {:type [:and types]
      ::items specs}))
 
-<<<<<<< HEAD
-(defmethod parse-form 'clojure.spec.alpha/merge [_ form]
-  (let [type-priority #((:type %) {:map 0
-                                   :multi-spec 1} 0)]
-=======
 (defmethod parse-form 'clojure.spec.alpha/merge [_ form options]
   (let [type-priority #(if (= (:type %) :multi-spec) 1 0)]
->>>>>>> cf0ce10 (fix recursive parse-spec visits)
     (apply impl/deep-merge (->> (rest form)
                                 (map #(parse-spec % options))
                                 (sort-by type-priority)))))

--- a/src/spec_tools/parse.cljc
+++ b/src/spec_tools/parse.cljc
@@ -193,7 +193,8 @@
      ::items specs}))
 
 (defmethod parse-form 'clojure.spec.alpha/merge [_ form options]
-  (let [type-priority #(if (= (:type %) :multi-spec) 1 0)]
+  (let [type-priority #((:type %) {:map 0
+                                   :multi-spec 1} 0)]
     (apply impl/deep-merge (->> (rest form)
                                 (map #(parse-spec % options))
                                 (sort-by type-priority)))))

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -840,3 +840,36 @@
        (is (st/spec? (st/merge ::qix ::qux)))
        (is (st/spec? (st/merge qix ::qux))))))
 
+<<<<<<< HEAD
+=======
+(s/def ::a242 int?)
+(s/def ::b242 int?)
+(s/def ::c242 int?)
+
+(deftest issue-242
+  (testing "parse-form should continue to work with [:or [:map]] specs"
+    (let [desired-spec (st/spec (s/merge (s/or :one (s/keys :req-un [::a242])
+                                               :two (s/keys :req-un [::b242]))
+                                         (s/keys :req-un [::c242])))]
+      (is (s/valid? desired-spec {:a242 1 :c242 2}))
+      (is (not (s/valid? desired-spec {:c242 2})))
+      (is (s/valid? desired-spec {:b242 2 :c242 3}))
+      (is (not (s/valid? desired-spec {:a242 1}))))))
+
+(s/def ::rec-pattern (s/coll-of (s/or :atr qualified-keyword?
+                                      :ref (s/map-of qualified-keyword?
+                                                     (s/or :rec-pattern ::rec-pattern)))))
+
+(deftest issue-244
+  (testing "stop rewalking recursive specs."
+    (let [correct-data [:core-test/stack
+                        {:core-test/overflow [:core-test/stackoverflow
+                                              {:core-test/over [:core-test/flow]}]}]
+          wrong-data [:core-test/stack
+                        {:core-test/overflow [:core-test/stackoverflow
+                                              {:core-test/over [:flow :is :not :right]}]}]]
+      (is (s/valid? ::rec-pattern correct-data))
+      (is (s/valid? (st/spec ::rec-pattern) correct-data))
+      (is (not (s/valid? ::rec-pattern wrong-data)))
+      (is (not (s/valid? (st/spec ::rec-pattern) wrong-data))))))
+>>>>>>> cf0ce10 (fix recursive parse-spec visits)

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -840,22 +840,6 @@
        (is (st/spec? (st/merge ::qix ::qux)))
        (is (st/spec? (st/merge qix ::qux))))))
 
-<<<<<<< HEAD
-=======
-(s/def ::a242 int?)
-(s/def ::b242 int?)
-(s/def ::c242 int?)
-
-(deftest issue-242
-  (testing "parse-form should continue to work with [:or [:map]] specs"
-    (let [desired-spec (st/spec (s/merge (s/or :one (s/keys :req-un [::a242])
-                                               :two (s/keys :req-un [::b242]))
-                                         (s/keys :req-un [::c242])))]
-      (is (s/valid? desired-spec {:a242 1 :c242 2}))
-      (is (not (s/valid? desired-spec {:c242 2})))
-      (is (s/valid? desired-spec {:b242 2 :c242 3}))
-      (is (not (s/valid? desired-spec {:a242 1}))))))
-
 (s/def ::rec-pattern (s/coll-of (s/or :atr qualified-keyword?
                                       :ref (s/map-of qualified-keyword?
                                                      (s/or :rec-pattern ::rec-pattern)))))
@@ -872,4 +856,3 @@
       (is (s/valid? (st/spec ::rec-pattern) correct-data))
       (is (not (s/valid? ::rec-pattern wrong-data)))
       (is (not (s/valid? (st/spec ::rec-pattern) wrong-data))))))
->>>>>>> cf0ce10 (fix recursive parse-spec visits)


### PR DESCRIPTION
Fixes #244 it is happening a similar problem that @ikitommi fixed for the visitor namespace in 2017. In order to keep the `parse-spec` interface the same and be able to pass around a variable to keep track of `qualified-keywords` already visited, I changed the arity of `parse-spec` and also from the inner implementation `parse-form`. This was the best way I figure out to keep the implementation functional and not introduce any mutable variable for tracking purpose.

Please, looking for improvements and ideas if any!
Thanks