### PR TITLE
Disable *transformer* variable inside a transformer call

### DIFF
--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -130,11 +130,10 @@
         (-options [_] options)
         (-encoder [_ spec _]
           (or (get spec encode-key)
-              (let [e (get encoders (parse/type-dispatch-value (:type spec)))]
-                (when e
-                  (fn [this x]
-                    (binding [*transformer* nil]
-                      (e this x)))))
+              (when-let [e (get encoders (parse/type-dispatch-value (:type spec)))]
+                (fn [this x]
+                  (binding [*transformer* nil]
+                    (e this x))))
               default-encoder))
         (-decoder [_ spec _]
           (or (get spec decode-key)

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -133,7 +133,7 @@
           (or (get spec encode-key)
               (when-let [e (get encoders (parse/type-dispatch-value (:type spec)))]
                 (fn [this x]
-                  (binding [*transformer* nil]
+                  (binding [*dynamic-conforming* (->DynamicConforming nil false nil)]
                     (e this x))))
               default-encoder))
         (-decoder [_ spec _]

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -130,7 +130,11 @@
         (-options [_] options)
         (-encoder [_ spec _]
           (or (get spec encode-key)
-              (get encoders (parse/type-dispatch-value (:type spec)))
+              (let [e (get encoders (parse/type-dispatch-value (:type spec)))]
+                (when e
+                  (fn [this x]
+                    (binding [*transformer* nil]
+                      (e this x)))))
               default-encoder))
         (-decoder [_ spec _]
           (or (get spec decode-key)

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -872,8 +872,8 @@
       (is (not (s/valid? (st/spec ::rec-pattern) wrong-data))))))
 
 
-(s/def ::epoch (s/int-in Long/MIN_VALUE Long/MAX_VALUE))
-(s/def ::nano (s/int-in 0 (Math/pow 10 9)))
+(s/def ::epoch (s/int-in 10 20))
+(s/def ::nano (s/int-in 0 100))
 (s/def ::time-basis #{:UTC :TAI})
 (s/def ::instant
   (st/spec {:spec (s/keys :req-un [::epoch ::nano ::time-basis]) :type :instant}))

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -880,7 +880,7 @@
 
 (defn tai->utc
   [_ {:keys [epoch nano time-basis] :as x}]
-  (if (= :TAI time-basis)
+  (if (and (s/valid? ::instant x) (= :TAI time-basis))
     {:epoch "Epoch converted"
      :nano nano
      :time-basis :UTC}


### PR DESCRIPTION
Idea about how to solve #240 . The solution here is to disable the `*transformer*` dynamic variable when a transform function is called. I think this is a reasonable thing to do to avoid StackOverFlow scenarios.

There is more details in #240 thread.

Thanks