### PR TITLE
Fix Issue 255's Strict Json Transformer

### DIFF
--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -434,11 +434,11 @@
           value {"keys" {:c1 "1" ::c2 "kikka"}
                  "keys2" {:c1 true}
                  "ints" [1 "1" "invalid" "3"]}]
-      (is (= {:keys {:c1 1 ::c2 :kikka}
+      (is (= {:keys {:c1 "1" ::c2 "kikka"}
               :keys2 {:c1 true}
               :ints #{1 "invalid" 3}}
              (st/coerce spec value st/string-transformer)))
-      (is (= {:keys {:c1 "1" ::c2 :kikka}
+      (is (= {:keys {:c1 "1" ::c2 "kikka"}
               :keys2 {:c1 true}
               :ints #{1 "1" "invalid" "3"}}
              (st/coerce spec value st/json-transformer)))))
@@ -971,7 +971,12 @@
        {:keyword :a :date #inst"2020-02-22T00:00:00.000-00:00"}
        (st/coerce ::issue-212-biiwide-spec
                   {:keyword "a" :date "2020-02-22"} strict-json-transformer)))
+  ;; last 2 examples, just because coercion works that way
   (is (=
-       {:keyword :a :int 1}
+       {:keyword :a :int "1"}
+       (st/coerce ::keyword-and-int
+                  {:keyword "a" :int "1"} strict-json-transformer)))
+  (is (=
+       {:keyword :a :int "1"}
        (st/coerce ::issue-212-biiwide-spec
                   {:keyword "a" :int "1"} strict-json-transformer))))

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -928,3 +928,22 @@
              {:epoch "Epoch converted"
               :nano 20
               :time-basis :UTC})))))
+
+(def strict-json-transformer
+  (st/type-transformer
+   st/strip-extra-keys-transformer   
+   st/json-transformer))
+
+(s/def ::a-string string?)
+(s/def ::a-map-with-string (s/keys :req-un [::a-string]))
+
+(s/def ::a-vector vector?)
+(s/def ::a-map-with-vector (s/keys :req-un [::a-vector]))
+
+(s/def ::issue-494-spec (s/or :foo ::a-map-with-string
+                              :bar ::a-map-with-vector))
+(deftest reitit-issue-494
+  (testing "s/or with s/keys and req-un on reitit's issue 494 example")
+  (is (= {:a-string "1"}
+         (st/coerce::issue-494-spec {:a-string 1} strict-json-transformer)))
+  (is (= {:a-vector ["foo"]} (st/coerce ::issue-494-spec {:a-vector ["foo"]}))))

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -957,3 +957,21 @@
   (testing "s/or with s/keys and req-un on issue 255 example")
   (is (= {:an-int 1}
          (st/coerce::issue-255-spec {:an-int 1} strict-json-transformer))))
+
+(s/def ::keyword keyword?)
+(s/def ::int int?)
+(s/def ::date inst?)
+(s/def ::issue-212-biiwide-spec (s/merge
+                                 (s/keys :req-un [::keyword])
+                                 (s/or :x (s/keys :req-un [::int])
+                                       :y (s/keys :req-un [::date]))))
+(deftest issue-212
+  (testing "s/or with s/keys and req-un on issue biiwide's 212 example")
+  (is (=
+       {:keyword :a :date #inst #inst"2020-02-22T00:00:00.000-00:00"}
+       (st/coerce ::issue-212-biiwide-spec
+                  {:keyword "a" :date "2020-02-22"} st/strip-extra-keys-transformer)))
+    (is (=
+       {:keyword :a :int 1}
+       (st/coerce ::issue-212-biiwide-spec
+                  {:keyword "a" :int "1"} st/strip-extra-keys-transformer))))

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -959,17 +959,19 @@
 (s/def ::keyword keyword?)
 (s/def ::int int?)
 (s/def ::date inst?)
-(s/def ::issue-212-biiwide-spec (s/merge
-                                 (s/keys :req-un [::keyword])
-                                 (s/or :x (s/keys :req-un [::int])
-                                       :y (s/keys :req-un [::date]))))
+
+(s/def ::keyword-and-int (s/keys :req-un [::keyword ::int]))
+(s/def ::keyword-and-date (s/keys :req-un [::keyword ::date]))
+(s/def ::issue-212-biiwide-spec (s/or :x ::keyword-and-date
+                                      :y ::keyword-and-int))
+
 (deftest issue-212
   (testing "s/or with s/keys and req-un on issue biiwide's 212 example")
   (is (=
        {:keyword :a :date #inst"2020-02-22T00:00:00.000-00:00"}
        (st/coerce ::issue-212-biiwide-spec
-                  {:keyword "a" :date "2020-02-22"} st/strip-extra-keys-transformer)))
-    (is (=
+                  {:keyword "a" :date "2020-02-22"} strict-json-transformer)))
+  (is (=
        {:keyword :a :int 1}
        (st/coerce ::issue-212-biiwide-spec
-                  {:keyword "a" :int "1"} st/strip-extra-keys-transformer))))
+                  {:keyword "a" :int "1"} strict-json-transformer))))

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -971,7 +971,8 @@
        {:keyword :a :date #inst"2020-02-22T00:00:00.000-00:00"}
        (st/coerce ::issue-212-biiwide-spec
                   {:keyword "a" :date "2020-02-22"} strict-json-transformer)))
-  ;; last 2 examples, just because coercion works that way
+  ;; last 2 examples, not happy with having ::int uncoerced, but that is
+  ;; how coerce works
   (is (=
        {:keyword :a :int "1"}
        (st/coerce ::keyword-and-int

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -940,23 +940,21 @@
 (s/def ::a-vector vector?)
 (s/def ::a-map-with-vector (s/keys :req-un [::a-vector]))
 
+(s/def ::an-int int?)
+(s/def ::a-map-with-int (s/keys :req-un [::an-int]))
+
 (s/def ::issue-494-spec (s/or :foo ::a-map-with-string
-                              :bar ::a-map-with-vector))
+                              :bar ::a-map-with-vector
+                              :baz ::a-map-with-int))
+
 (deftest reitit-issue-494
   (testing "s/or with s/keys and req-un on reitit's issue 494 example")
-  (is (= {:a-string "1"}
-         (st/coerce ::issue-494-spec {:a-string 1} strict-json-transformer)))
-  (is (= {:a-vector ["foo"]} (st/coerce ::issue-494-spec {:a-vector ["foo"]}))))
+  (is (= {:a-string "bar"}
+         (st/coerce ::issue-494-spec {:a-string "bar"} strict-json-transformer)))
+  (is (= {:an-int 0}
+         (st/coerce ::issue-494-spec {:an-int 0} strict-json-transformer)))
+  (is (= {:a-vector ["foo"]} (st/coerce ::issue-494-spec {:a-vector ["foo"]} strict-json-transformer))))
 
-(s/def ::an-int int?)
-(s/def ::a-string string?)
-(s/def ::issue-255-spec (s/or
-                         :an-int (s/keys :req-un [::an-int])
-                         :a-string (s/keys :req-un [::a-string])))
-(deftest issue-255
-  (testing "s/or with s/keys and req-un on issue 255 example")
-  (is (= {:an-int 1}
-         (st/coerce ::issue-255-spec {:an-int 1} strict-json-transformer))))
 
 (s/def ::keyword keyword?)
 (s/def ::int int?)

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -945,7 +945,7 @@
 (deftest reitit-issue-494
   (testing "s/or with s/keys and req-un on reitit's issue 494 example")
   (is (= {:a-string "1"}
-         (st/coerce::issue-494-spec {:a-string 1} strict-json-transformer)))
+         (st/coerce ::issue-494-spec {:a-string 1} strict-json-transformer)))
   (is (= {:a-vector ["foo"]} (st/coerce ::issue-494-spec {:a-vector ["foo"]}))))
 
 (s/def ::an-int int?)
@@ -956,7 +956,7 @@
 (deftest issue-255
   (testing "s/or with s/keys and req-un on issue 255 example")
   (is (= {:an-int 1}
-         (st/coerce::issue-255-spec {:an-int 1} strict-json-transformer))))
+         (st/coerce ::issue-255-spec {:an-int 1} strict-json-transformer))))
 
 (s/def ::keyword keyword?)
 (s/def ::int int?)
@@ -968,7 +968,7 @@
 (deftest issue-212
   (testing "s/or with s/keys and req-un on issue biiwide's 212 example")
   (is (=
-       {:keyword :a :date #inst #inst"2020-02-22T00:00:00.000-00:00"}
+       {:keyword :a :date #inst"2020-02-22T00:00:00.000-00:00"}
        (st/coerce ::issue-212-biiwide-spec
                   {:keyword "a" :date "2020-02-22"} st/strip-extra-keys-transformer)))
     (is (=

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -947,3 +947,13 @@
   (is (= {:a-string "1"}
          (st/coerce::issue-494-spec {:a-string 1} strict-json-transformer)))
   (is (= {:a-vector ["foo"]} (st/coerce ::issue-494-spec {:a-vector ["foo"]}))))
+
+(s/def ::an-int int?)
+(s/def ::a-string string?)
+(s/def ::issue-255-spec (s/or
+                         :an-int (s/keys :req-un [::an-int])
+                         :a-string (s/keys :req-un [::a-string])))
+(deftest issue-255
+  (testing "s/or with s/keys and req-un on issue 255 example")
+  (is (= {:an-int 1}
+         (st/coerce::issue-255-spec {:an-int 1} strict-json-transformer))))


### PR DESCRIPTION
The method for `walk :or` from [spec-tools core](https://github.com/metosin/spec-tools/blob/master/src/spec_tools/core.cljc#L292) was changed.

Previously it was  reducing over all the spec's items (different specs within the `spec/or`).
It was essentialy coercing to a given item **and** the next given item and so forth and so on. 
This caused an `strict-json-transformer` to behave inconsistently.

@ikitommi 's comment at [issue 178](https://github.com/metosin/spec-tools/issues/178), is implemented here.
The method now coerces to all items, and chooses one based on validity or previous behavior.

### Issues with the proposed solution
The main issue is that the behavior of the method changes. As it only applies a particular coercion now.

[**Testing Composed**](https://github.com/metosin/spectools/blob/master/test/cljc/spec_tools/core_test.cljc#L427)
In that particular test, the value under keys `["keys" ::c2]` gets coerced to a `keyword`. 
That is not in the`spec`. 

On the same example `["keys" :c1]` will not get coerced to an int now. But that is how coerce works
as [ilustrated here](https://github.com/JoaquinIglesiasTurina/spec-tools/blob/issue-255-strict-json-transformer/test/cljc/spec_tools/core_test.cljc#L974). 

**Parametrization Matters**
Minimal examples have been given for this particular issue. Those have been adapted as tests.
However, the `spec` must be written in a particular way. I find this a major flaw.
[This](https://github.com/metosin/spec-tools/pull/259/commits/7dd66d7bc682c3cfadd7584e9abea0e6a6c46c11) is the clearest example.