### PR TITLE
Fixes nested reasons being overwritten by outer spec's reason #171.

### DIFF
--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -460,7 +460,7 @@
           spec-reason (:reason this)
           with-reason (fn [problem]
                         (cond-> problem
-                                spec-reason
+                                (and spec-reason (not (:reason problem)))
                                 (assoc :reason spec-reason)))]
       (if problems
         (map with-reason problems))))


### PR DESCRIPTION
This should fix #171, where a reason set on an outer spec overwrites the inner problem's reason.