### PR TITLE
Fixed link to Spec driven transformations

### DIFF
--- a/docs/07_spec_records.md
+++ b/docs/07_spec_records.md
@@ -2,7 +2,7 @@
 
 Tools for enabling adding meta-data to Specs and 
 
-To enable spec metadata and features like [Spec driven transformations](#spec-driven-transformations), Spec-tools introduces extendable Spec Records, `Spec`s. They wrap specs and act like specs or 1-arity functions. Specs are created with `spec-tools.core/spec` macro or with the underlying `spec-tools.core/create-spec` function.
+To enable spec metadata and features like [Spec driven transformations](10_spec_transformations.md), Spec-tools introduces extendable Spec Records, `Spec`s. They wrap specs and act like specs or 1-arity functions. Specs are created with `spec-tools.core/spec` macro or with the underlying `spec-tools.core/create-spec` function.
 
 The following Spec keys having a special meaning:
 


### PR DESCRIPTION
While reading the documentation I realized there was a broken link from the "Spec Records" to the "Spec driven Transformations" page