### PR TITLE
Fix create-spec documentation

### DIFF
--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -519,18 +519,20 @@
 (defn create-spec
   "Creates a Spec instance from a map containing the following keys:
 
-           :spec  the wrapped spec predicate (default to `any?`)
-           :form  source code of the spec predicate, if :spec is a spec,
-                  :form is read with `s/form` out of it. For non-spec
-                  preds, spec-tools.form/resolve-form is called, if still
-                  not available, spec-creation will fail.
-           :type  optional type for the spec. if not set, will be auto-
-                  resolved via spec-tools.parse/parse-spec (optional)
-         :reason  reason to be added to problems with s/explain (optional)
-            :gen  generator function for the spec (optional)
-           :name  name of the spec (optional)
-    :description  description of the spec (optional)
-          :xx/yy  any qualified keys can be added (optional)"
+  ```
+          :spec  the wrapped spec predicate (default to `any?`)
+          :form  source code of the spec predicate, if :spec is a spec,
+                 :form is read with `s/form` out of it. For non-spec
+                 preds, spec-tools.form/resolve-form is called, if still
+                 not available, spec-creation will fail.
+          :type  optional type for the spec. if not set, will be auto-
+                 resolved via spec-tools.parse/parse-spec (optional)
+        :reason  reason to be added to problems with s/explain (optional)
+           :gen  generator function for the spec (optional)
+          :name  name of the spec (optional)
+   :description  description of the spec (optional)
+         :xx/yy  any qualified keys can be added (optional)
+  ```"
   [{:keys [spec type form] :as m}]
   (when (qualified-keyword? spec)
     (assert (get-spec spec) (str " Unable to resolve spec: " spec)))


### PR DESCRIPTION
Hello :D
I saw a problem in the `create-spec` documentation and this PR aims to fix it.

From this:

<img width="690" alt="Screenshot 2023-02-08 at 18 26 20" src="https://user-images.githubusercontent.com/4502764/217654809-b8201620-3198-4a90-9580-6b39f8e095a8.png">

To this:

<img width="705" alt="Screenshot 2023-02-08 at 18 27 09" src="https://user-images.githubusercontent.com/4502764/217654816-d51e81e2-5b66-4fc1-b3f4-c0745a71e028.png">
