### PR TITLE
`st/strip-extra-keys-transformer` not handling merged `s/or` #271

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -47,7 +47,7 @@
             "perf" ["with-profile" "default,dev,perf"]
             "test-clj" ["all" "do" ["test"] ["check"]]
             "test-phantom" ["doo" "phantom" "test"]
-            "test-advanced" ["doo" "phantom" "advanced-test"]
+            "test-advanced" ["doo" "node" "advanced-test"]
             "test-node" ["doo" "node" "node-test"]}
   ;; Below, :process-shim false is workaround for <https://github.com/bensu/doo/pull/141>
   :cljsbuild {:builds [{:id "test"
@@ -63,6 +63,7 @@
                                    :output-dir "target/advanced_out"
                                    :main spec-tools.doo-runner
                                    :optimizations :advanced
+                                   :target :nodejs
                                    :process-shim false}}
                        ;; Node.js requires :target :nodejs, hence the separate
                        ;; build configuration.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,7 +2,7 @@
 set -e
 case $1 in
     cljs)
-        lein "do" test-phantom once, test-node once, test-advanced once
+        lein "do" test-node once, test-advanced once
         ;;
     clj)
         lein test-clj

--- a/src/spec_tools/core.cljc
+++ b/src/spec_tools/core.cljc
@@ -405,9 +405,10 @@
                       (keyword? x) (recur (s/get-spec x))
                       (spec? x) x
                       (s/spec? x) (create-spec {:spec x})
-                      (map? x) (if (qualified-keyword? (:spec x))
-                                 (recur (s/get-spec (:spec x)))
-                                 (create-spec (update x :spec (fnil identity any?))))))
+                      (map? x) (cond
+                                 (some (comp #{"spec-tools.parse"} namespace key) x) (map->Spec x)
+                                 (qualified-keyword? (:spec x)) (recur (s/get-spec (:spec x)))
+                                 :else (create-spec x))))
           transformed (if-let [transform (if (and transformer (not (:skip? options)))
                                            (-decoder transformer this value))]
                         (transform this value) value)]

--- a/test/cljc/spec_tools/core_test.cljc
+++ b/test/cljc/spec_tools/core_test.cljc
@@ -818,11 +818,15 @@
 
 (deftest issue-179
   (testing "st/coerce can work properly with s/or specs"
-    (let [chevy {:doors 4}]
+    (let [chevy {:doors 4 :a 1 :junk "junk"}]
       (is (= (st/coerce ::car chevy st/strip-extra-keys-transformer)
              {:doors 4}))
       (is (= (st/coerce ::vehicle chevy st/strip-extra-keys-transformer)
              {:doors 4}))
+      (is (= {:doors 4 :a 1}
+             (st/coerce (s/merge ::vehicle
+                                 (s/keys :opt-un [::a]))
+                        chevy st/strip-extra-keys-transformer)))
       (is (= (st/coerce ::new-vehicle {:rodas [1 "1" 3]} st/strip-extra-keys-transformer)
              {:rodas #{1 "1" 3}}))
       (is (= (st/coerce ::s {:keyword "a" :date "2020-02-22"} st/json-transformer)


### PR DESCRIPTION
Fix for #271

When merging an `s/or` with a `s/keys` this solution merges the `s/keys` into every `s/or` e.g.
```clojure
(s/merge (s/or :a (s/keys :req-un [::a])
               :b (s/keys :req-un [::b]))
         (s/keys :req-un [::c]))
```
becomes
```clojure
(s/or :a (s/keys :req-un [::a ::c])
      :b (s/keys :req-un [::b ::c]))
```

**Note** Without the change in [src/spec_tools/core.cljc](https://github.com/metosin/spec-tools/commit/38a19120d9c8d2eaca8b09b5a522d2a2fb5c2525#diff-ea30c8a224677b3de6eb66ba5be32085143708fc05ee854f3dec633475733131R409) the sub-spec of the `s/or` got re-parsed missing the extra info stuffed in there from the merge. This is a nasty and perhaps brittle solution, but I was unable to come up with a better one without more changes