### PR TITLE
Add option to create references for models

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
                              [lein-pprint "1.3.2"]]
                    :jvm-opts ^:replace ["-server"]
                    ;:global-vars {*warn-on-reflection* true}
-                   :dependencies [[org.clojure/clojure "1.10.0"]
+                   :dependencies [[org.clojure/clojure "1.11.1"]
                                   [org.clojure/clojurescript "1.10.520"]
                                   [criterium "0.4.5"]
                                   [prismatic/schema "1.1.12"]

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
-(defproject metosin/spec-tools "0.10.5"
-  :description "Clojure(Script) tools for clojure.spec"
+(defproject net.hughpowell/spec-tools "0.10.6"
+  :description "Clojure(Script) tools for clojure.spec - forked from github.com/metosin/spec-tools"
   :url "https://github.com/metosin/spec-tools"
   :license {:name "Eclipse Public License", :url "https://www.eclipse.org/legal/epl-2.0/"}
   :test-paths ["test/clj" "test/cljc"]
@@ -39,7 +39,7 @@
                                   ; If the library gets updated with fixes it would be desirable to switch back to it.
                                   ;[com.bhauman/spell-spec "0.1.1"]
                                   [expound "0.8.4"]
-																																		[metosin/muuntaja "0.6.7"]
+                                  [metosin/muuntaja "0.6.7"]
                                   [metosin/ring-swagger "0.26.2"]
                                   [metosin/scjsv "0.6.1"]]}
              :perf {:jvm-opts ^:replace ["-server"]}}

--- a/test/cljc/spec_tools/swagger/core_test.cljc
+++ b/test/cljc/spec_tools/swagger/core_test.cljc
@@ -252,7 +252,25 @@
                                            :type "string"}},
                       :required ["integer" "spec"],
                       :x-nullable true}}]
-           (swagger/extract-parameter :body (s/nilable ::keys2))))))
+           (swagger/extract-parameter :body (s/nilable ::keys2)))))
+
+  (testing "definitions are raised to the top of the parameter"
+    (is (=
+          [{:in "body"
+            :name "spec-tools.swagger.core-test/ref-spec"
+            :description ""
+            :required true
+            :schema {:$ref "#/definitions/RefSpec"
+                     ::swagger/definitions {"RefSpec" {:type "object"
+                                                       :properties {"integer" {:type "integer"}
+                                                                    "spec" {:type "string"
+                                                                            :description "description"
+                                                                            :title "spec-tools.swagger.core-test/spec"
+                                                                            :default "123"
+                                                                            :example "swagger-example"}}
+                                                       :required ["integer" "spec"]
+                                                       :description "description"}}}}]
+          (swagger/extract-parameter :body ::ref-spec {:refs? true})))))
 
 #?(:clj
    (deftest test-parameter-validation


### PR DESCRIPTION
When users use Swagger to automatically generate clients inline models create can create multiple classes for the logically same model.

Add and option (`:refs?`) to create references and a high level `definitions` key to hold references.