### PR TITLE
Add option to create references for models

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Posts:
 
 [![Clojars Project](http://clojars.org/metosin/spec-tools/latest-version.svg)](http://clojars.org/metosin/spec-tools)
 
-Requires Java 1.8, tested with Clojure `1.10.0` and ClojureScript `1.10.520`+.
+Requires Java 1.8, tested with Clojure `1.11.0` and ClojureScript `1.11.4`+.
 
 Status: **Alpha** (as spec is still alpha too).
 

--- a/src/spec_tools/swagger/core.cljc
+++ b/src/spec_tools/swagger/core.cljc
@@ -239,11 +239,14 @@
           x))
       x)))
 
-(defn- raise-refs-to-top [x]
-  (cond-> x
-    (:paths x) (->
-                 (assoc :definitions (apply merge (map :definitions (mapcat vals (vals (:paths x))))))
-                 (update :paths update-vals (fn [path] (update-vals path #(dissoc % :definitions)))))))
+(defn- raise-refs-to-top [swagger-doc]
+  (let [swagger-doc'
+        (cond-> swagger-doc
+          (:paths swagger-doc) (->
+                                 (assoc :definitions (apply merge (map :definitions (mapcat vals (vals (:paths swagger-doc))))))
+                                 (update :paths update-vals (fn [path] (update-vals path #(dissoc % :definitions))))))]
+    (cond-> swagger-doc'
+      (nil? (:definitions swagger-doc')) (dissoc swagger-doc' :definitions))))
 
 ;;
 ;; generate the swagger spec

--- a/test/cljc/spec_tools/swagger/core_test.cljc
+++ b/test/cljc/spec_tools/swagger/core_test.cljc
@@ -252,7 +252,25 @@
                                            :type "string"}},
                       :required ["integer" "spec"],
                       :x-nullable true}}]
-           (swagger/extract-parameter :body (s/nilable ::keys2))))))
+           (swagger/extract-parameter :body (s/nilable ::keys2)))))
+
+  (testing "definitions are raised to the top of the parameter"
+    (is (=
+          [{:in "body"
+            :name "spec-tools.swagger.core-test/ref-spec"
+            :description ""
+            :required true
+            :schema {:$ref "#/definitions/RefSpec"
+                     ::swagger/definitions {"RefSpec" {:type "object"
+                                                       :properties {"integer" {:type "integer"}
+                                                                    "spec" {:type "string"
+                                                                            :description "description"
+                                                                            :title "spec-tools.swagger.core-test/spec"
+                                                                            :default "123"
+                                                                            :example "swagger-example"}}
+                                                       :required ["integer" "spec"]
+                                                       :description "description"}}}}]
+          (swagger/extract-parameter :body ::ref-spec {:refs? true})))))
 
 #?(:clj
    (deftest test-parameter-validation

--- a/test/cljc/spec_tools/swagger/core_test.cljc
+++ b/test/cljc/spec_tools/swagger/core_test.cljc
@@ -473,6 +473,23 @@
             {::swagger/responses {200 {:schema (st/create-spec
                                                  {:spec ::user
                                                   :swagger/title "User"})}}}
+            {:refs? true}))))
+
+  (testing "::responses with refs in additionalProperties"
+    (is (=
+          {:responses {200 {:schema {:$ref "#/definitions/Every Test"}, :description ""}},
+           :definitions {"Every Test" {:type "object",
+                                       :additionalProperties {:$ref "#/definitions/spec-tools.swagger.core-test.address"}},
+                         "spec-tools.swagger.core-test.address" {:type "object",
+                                                                 :properties {"street" {:type "string"},
+                                                                              "city" {:enum [:tre :hki],
+                                                                                      :type "string",
+                                                                                      :x-nullable true}},
+                                                                 :required ["street" "city"]}}}
+          (swagger/swagger-spec
+            {::swagger/responses {200 {:schema (st/create-spec
+                                                 {:spec (s/every-kv ::id ::address)
+                                                  :swagger/title "Every Test"})}}}
             {:refs? true})))))
 
 #?(:clj


### PR DESCRIPTION
When users use Swagger to automatically generate clients inline models create can create multiple classes for the logically same model.

Add and option (`:refs?`) to create references and a high level `definitions` key to hold references.