### PR TITLE
Support transform of multi-spec to JSON Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Support transforming schema to JSON Schema. PR [#281](https://github.com/metosin/spec-tools/pull/281)
+
 # 0.10.6 (2023-08-28)
 
 * Deprecate `spec-tools.openapi/openapi-spec`

--- a/src/spec_tools/json_schema.cljc
+++ b/src/spec_tools/json_schema.cljc
@@ -228,6 +228,9 @@
 (defmethod accept-spec 'spec-tools.core/merge [_ spec children options]
   (accept-merge children spec options))
 
+(defmethod accept-spec 'clojure.spec.alpha/multi-spec [_ _ children _]
+  {:anyOf children})
+
 (defmethod accept-spec 'clojure.spec.alpha/every [_ spec children options]
   (let [form (impl/extract-form spec)
         {:keys [type]} (parse/parse-spec form)]

--- a/src/spec_tools/visitor.cljc
+++ b/src/spec_tools/visitor.cljc
@@ -77,6 +77,12 @@
 (defmethod visit-spec 'spec-tools.core/merge [spec accept options]
   (visit-merge spec accept options))
 
+(defmethod visit-spec 'clojure.spec.alpha/multi-spec [spec accept options]
+  (let [methods-specs (->> (impl/extract-form spec)
+                               (parse/get-multi-spec-sub-specs)
+                               (into {}))]
+    (accept 'clojure.spec.alpha/multi-spec spec (mapv #(visit (val %) accept options) methods-specs) options)))
+
 (defmethod visit-spec 'clojure.spec.alpha/every [spec accept options]
   (let [[_ inner-spec] (impl/extract-form spec)]
     (accept 'clojure.spec.alpha/every spec [(visit inner-spec accept options)] options)))


### PR DESCRIPTION
```clojure
(defmulti event-type :action)

(s/def :event.payload.add/action #{:add})
(s/def :event.payload.add/payload int?)

(defmethod event-type :add
  [_]
  (s/keys :req-un [:event.payload.add/action :event.payload.add/payload]))

(s/def :event.payload.result/action #{:result})
(s/def :event.payload.result/payload nil?)

(defmethod event-type :result
  [_]
  (s/keys :req-un [:event.payload.result/action]
          :opt-un [:event.payload.result/payload]))

(s/def ::event.payload
  (s/multi-spec event-type :action))
=> nil
=> :event.payload.add/action
=> :event.payload.add/payload
=> #object[clojure.lang.MultiFn 0x2a66cd26 "clojure.lang.MultiFn@2a66cd26"]
=> :event.payload.result/payload
=> :event.payload.result/action
=> #object[clojure.lang.MultiFn 0x2a66cd26 "clojure.lang.MultiFn@2a66cd26"]
=> :damian-test/event.payload
(json-schema/transform ::event.payload)
=>
{:anyOf [{:type "object", :properties {"action" {:enum [:result]}, "payload" {:type "null"}}, :required ["action"]}
         {:type "object",
          :properties {"action" {:enum [:add]}, "payload" {:type "integer", :format "int64"}},
          :required ["action" "payload"]}]}

```

IMO it's best as a convention to add specs like `(s/def :event.payload.add/action #{:add})`. It might look surprising in the beginning. After all, it's already enforced by the `multimethod` mechanisms. But making that extra step prevents two issues:
1. the json schema is incapable of picking up the quirks of complex `dispatch-fn`s of multimethods. So without it the resulting json schema would be incomplete.
2. whenever you need to use spec generators to create samples, the methods again won't pickup the logic without that extra step.
```clojure
(gen/sample (s/gen ::event.payload))
=>
({:payload nil, :action :result}
 {:action :result}
 {:action :add, :payload 0}
 {:payload nil, :action :result}
 {:action :add, :payload -1}
 {:payload nil, :action :result}
 {:action :add, :payload -9}
 {:action :add, :payload -1}
 {:action :result}
 {:action :add, :payload -104})
```

